### PR TITLE
Bug Fix on New and Delete Operators

### DIFF
--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -42,7 +42,6 @@ JVMImage::JVMImage(J9JavaVM *javaVM) :
 
 JVMImage::~JVMImage()
 {
-    delete _jvmInstance;
 }
 
 //should be called once the image memory is allocated
@@ -58,10 +57,13 @@ JVMImage::initializeMonitor()
 JVMImage *
 JVMImage::createInstance(J9JavaVM *vm)
 {
+    PORT_ACCESS_FROM_JAVAVM(vm);
+    
+    _jvmInstance = (JVMImage *)j9mem_allocate_memory(sizeof(JVMImage), J9MEM_CATEGORY_CLASSES);
     if (_jvmInstance != NULL) {
-        _jvmInstance = new JVMImage(vm);
+        new(_jvmInstance) JVMImage(vm);   
     }
-
+    
     return _jvmInstance;
 }
 

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -33,12 +33,10 @@
 
 class JVMImage
 {
-private:
+public:
 	JVMImage(J9JavaVM *vm);
 	~JVMImage();
 
-	bool initializeMonitor();
-public:
 	static JVMImage* createInstance(J9JavaVM *vm);
 	static JVMImage* getInstance();
 
@@ -53,6 +51,8 @@ public:
 	OMRPortLibrary* getPortLibrary() { return &_portLibrary; }
 public:
 	static const UDATA INITIAL_IMAGE_SIZE;
+protected:
+	void *operator new(size_t size, void *memoryPointer) { return memoryPointer; }
 private:
 	static JVMImage *_jvmInstance;
 
@@ -64,6 +64,8 @@ private:
 	omrthread_monitor_t _jvmImageMonitor;
 
 	char *_dumpFileName;
+
+	bool initializeMonitor();
 };
 
 #endif /* JVMIMAGE_H_ */


### PR DESCRIPTION
- New and Delete symbols not loaded in binary
- Used new placement operator after mallocing space
- overrided new operator
- removed delete inside of destructor (causes infinite recursive loop)

Signed-off-by: Vinoshan Tharmalenkam <Vinoshan.Tharmalenkam@ibm.com>