### PR TITLE
VM Variables/Initialization and Error Handling

### DIFF
--- a/runtime/oti/jvmimage_api.h
+++ b/runtime/oti/jvmimage_api.h
@@ -54,9 +54,19 @@ void image_mem_free_memory(struct OMRPortLibrary* portLibrary, void* memoryPoint
 /*
 * Creates and allocates the jvm image and its' heap
 *
-* @param vm[in] the default port library
+* @param vm[in] the java vm 
+*
+* @return 0 on fail, 1 on success
 */
-void create_and_allocate_jvm_image(J9JavaVM *vm);
+UDATA initializeJVMImage(J9JavaVM *vm);
+
+/*
+* Shut down sequence of JVMImage
+* Frees memory of heap variables and jvmimage instance
+*
+* @param vm[in] the java vm 
+*/
+void shutdownJVMImage(J9JavaVM *vm);
 
 #ifdef __cplusplus
 }

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -40,15 +40,19 @@ public:
 	static JVMImage* createInstance(J9JavaVM *vm);
 	static JVMImage* getInstance();
 
-	void allocateImageMemory(J9JavaVM *vm, UDATA size);
+	void* allocateImageMemory(UDATA size);
 	void reallocateImageMemory(UDATA size);
 	void* subAllocateMemory(uintptr_t byteAmount);
 	void freeSubAllocatedMemory(void *memStart);
 
-	void readImageFromFile();
+	bool readImageFromFile();
 	void storeImageInFile();
 
+	bool initializeMonitor();
+	void destroyMonitor();
+
 	OMRPortLibrary* getPortLibrary() { return _portLibrary; }
+	bool isWarmRun() { return _isWarmRun; }
 public:
 	static const UDATA INITIAL_IMAGE_SIZE;
 protected:
@@ -56,6 +60,9 @@ protected:
 private:
 	static JVMImage *_jvmInstance;
 
+	J9JavaVM* _vm;
+
+	void* _heapBase;
 	J9Heap *_heap;
 	UDATA _currentImageSize;
 	bool _isImageAllocated;
@@ -64,8 +71,7 @@ private:
 	omrthread_monitor_t _jvmImageMonitor;
 
 	char *_dumpFileName;
-
-	bool initializeMonitor();
+	bool _isWarmRun;
 };
 
 #endif /* JVMIMAGE_H_ */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2071,8 +2071,11 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 
 			if (NULL == (vm->jniWeakGlobalReferences = pool_new(sizeof(UDATA), 0, 0, POOL_NO_ZERO, J9_GET_CALLSITE(), J9MEM_CATEGORY_JNI, POOL_FOR_PORT(vm->portLibrary))))
 				goto _error;
-
-			create_and_allocate_jvm_image(vm);
+			
+			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN | J9_EXTENDED_RUNTIME2_RAMSTATE_COLD_RUN)
+				&& 0 == initializeJVMImage(vm)) {
+				goto _error;
+			}
 
 			if (NULL == (vm->classLoadingStackPool = pool_new(sizeof(J9ClassLoadingStackElement),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(vm->portLibrary))))
 				goto _error;


### PR DESCRIPTION
- set filename and size inside jvmimage
- restructured initialization process to handle error and free memory
- created shutdown method and sequence

Signed-off-by: akshayben <akshayben@ibm.com>