### PR TITLE
Registering Structure and Class Loader Allocation

### DIFF
--- a/runtime/cfdumper/CMakeLists.txt
+++ b/runtime/cfdumper/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(cfdump
 
 	${j9vm_BINARY_DIR}/vm/ut_j9vm.c
 	${j9vm_SOURCE_DIR}/vm/stringhelpers.cpp
+	${j9vm_SOURCE_DIR}/vm/JVMImage.cpp
 	${j9vm_SOURCE_DIR}/vm/KeyHashTable.c
 	${j9vm_SOURCE_DIR}/vm/ModularityHashTables.c
 	${j9vm_SOURCE_DIR}/vm/dllsup.c

--- a/runtime/cfdumper/module.xml
+++ b/runtime/cfdumper/module.xml
@@ -40,6 +40,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 		<vpaths>
 			<vpath pattern="ut_j9vm.c" path="../vm" augmentObjects="true" type="relativepath"/>
 			<vpath pattern="stringhelpers.cpp" path="../vm" augmentObjects="true" type="relativepath"/>
+			<vpath pattern="JVMImage.cpp" path="../vm" augmentObjects="true" type="relativepath"/>
 			<vpath pattern="KeyHashTable.c" path="../vm" augmentObjects="true" type="relativepath"/>
 			<vpath pattern="ModularityHashTables.c" path="../vm" augmentObjects="true" type="relativepath"/>
 			<vpath pattern="dllsup.c" path="../vm" augmentObjects="true" type="relativepath"/>

--- a/runtime/oti/jvmimage.h
+++ b/runtime/oti/jvmimage.h
@@ -23,7 +23,39 @@
 #ifndef jvmimage_h
 #define jvmimage_h
 
-#define OMRPORT_FROM_IMAGE JVMImage::getInstance()->getPortLibrary();
+#define IS_WARM_RUN(javaVM) J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN)
+#define IS_COLD_RUN(javaVM) J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_COLD_RUN)
+#define OMRPORT_FROM_IMAGE() getImagePortLibrary()
+
+#define INITIAL_CLASSLOADER_TABLE_SIZE 3
+#define INITIAL_CLASS_TABLE_SIZE 10
+#define INITIAL_CLASSPATH_TABLE_SIZE 10
+
+enum ImageRC {
+	IMAGE_OK = BCT_ERR_NO_ERROR,
+	IMAGE_ERROR = BCT_ERR_GENERIC_ERROR,
+};
+
+/* forward struct declarations */
+struct ImageTableHeader;
+struct JVMImageData;
+
+//allows us to dump this struct into file and reload easier
+//allocated space for image data is longer than sizeof(JVMImageData)
+typedef struct JVMImageData {
+	UDATA imageSize;
+	J9WSRP classLoaderTable;
+	J9WSRP classSegmentTable;
+	J9WSRP classPathEntryTable;
+} JVMImageData;
+
+//table allows us to walk through different stored structures
+typedef struct ImageTableHeader {
+	J9WSRP tableHead;
+	J9WSRP tableTail; //tail needed for O(1) append
+	UDATA tableSize;
+	UDATA currentSize;
+} ImageTableHeader;
 
 struct JVMImageHeader
 {

--- a/runtime/oti/jvmimage_api.h
+++ b/runtime/oti/jvmimage_api.h
@@ -36,7 +36,7 @@ extern "C" {
 * 
 * @param size[in] size to allocate
 *
-* returns pointer to allocated memory on success, NULL on failure 
+* @return pointer to allocated memory on success, NULL on failure 
 */
 void* mem_allocate_memory(uintptr_t byteAmount);
 
@@ -48,7 +48,7 @@ void* mem_allocate_memory(uintptr_t byteAmount);
 * @param callSite[in] location memory alloc is called from
 * @param category[in] category of memory alloc
 *
-* returns pointer to allocated memory on success, NULL on failure 
+* @return pointer to allocated memory on success, NULL on failure 
 */
 void* image_mem_allocate_memory(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, const char *callSite, uint32_t category);
 
@@ -75,6 +75,35 @@ void image_mem_free_memory(struct OMRPortLibrary *portLibrary, void *memoryPoint
 * @return 0 on fail, 1 on success
 */
 UDATA initializeJVMImage(J9JavaVM *vm);
+
+/*
+* Registers class loader in table
+*
+* @param classLoader[in] J9ClassLoader to register
+*/
+void registerClassLoader(J9ClassLoader *classLoader);
+
+/*
+* Registers class segment in table
+*
+* @param clazz[in] J9Class to register
+*/
+void registerClassSegment(J9Class *clazz);
+
+/*
+* Registers class path entry in table
+*
+* @param cpEntry[in] J9ClassPathEntry to register
+*/
+void registerCPEntry(J9ClassPathEntry *cpEntry);
+
+/*
+* Returns the port library used by the image
+* Do not use directly but through macro defined in jvmimage.h
+*
+* @return pointer to port library of image on success, NULL on failure
+*/
+OMRPortLibrary* getImagePortLibrary();
 
 /*
 * Shut down sequence of JVMImage

--- a/runtime/tests/vm/CMakeLists.txt
+++ b/runtime/tests/vm/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(vmtest
 
 	#TODO this should maybe be refactored?
 	${j9vm_SOURCE_DIR}/vm/description.c
+	${j9vm_SOURCE_DIR}/vm/JVMImage.cpp
 	${j9vm_SOURCE_DIR}/vm/KeyHashTable.c
 	${j9vm_SOURCE_DIR}/vm/ModularityHashTables.c
 	${j9vm_SOURCE_DIR}/vm/resolvefield.cpp

--- a/runtime/tests/vm/module.xml
+++ b/runtime/tests/vm/module.xml
@@ -45,6 +45,7 @@
 		</makefilestubs>
 		<vpaths>
 			<vpath path="j9vm" pattern="description.c" augmentObjects="true"/>
+			<vpath path="j9vm" pattern="JVMImage.cpp" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="KeyHashTable.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="ModularityHashTables.c" augmentObjects="true"/>
 			<vpath path="j9vm" pattern="resolvefield.cpp" augmentObjects="true"/>

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -269,7 +269,11 @@ hashClassTableNew(J9JavaVM *javaVM, U_32 initialSize)
 		flags |= J9HASH_TABLE_DO_NOT_GROW;
 	}
 
-	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(KeyHashTableClassEntry), sizeof(char *), flags, J9MEM_CATEGORY_CLASSES, classHashFn, classHashEqualFn, NULL, javaVM);
+	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
+	if (IS_COLD_RUN(javaVM)) {
+		privatePortLibrary = OMRPORT_FROM_IMAGE();
+	}
+	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(KeyHashTableClassEntry), sizeof(char *), flags, J9MEM_CATEGORY_CLASSES, classHashFn, classHashEqualFn, NULL, javaVM);
 }
 
 J9Class *
@@ -546,7 +550,11 @@ hashClassLocationTableNew(J9JavaVM *javaVM, U_32 initialSize)
 {
 	U_32 flags = J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION;
 
-	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(J9ClassLocation), sizeof(char *), flags, J9MEM_CATEGORY_CLASSES, classLocationHashFn, classLocationHashEqualFn, NULL, javaVM);
+	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
+	if (IS_COLD_RUN(javaVM)) {
+		privatePortLibrary = OMRPORT_FROM_IMAGE();
+	}
+	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(J9ClassLocation), sizeof(char *), flags, J9MEM_CATEGORY_CLASSES, classLocationHashFn, classLocationHashEqualFn, NULL, javaVM);
 }
 
 static UDATA

--- a/runtime/vm/ModularityHashTables.c
+++ b/runtime/vm/ModularityHashTables.c
@@ -123,14 +123,18 @@ hashModuleNameTableNew(J9JavaVM *javaVM, U_32 initialSize)
 {
 	U_32 flags = J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION;
 
-	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, moduleNameHashFn, moduleNameHashEqualFn, NULL, javaVM);
+	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
+	if (IS_COLD_RUN(javaVM)) {
+		privatePortLibrary = OMRPORT_FROM_IMAGE();
+	}
+	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, moduleNameHashFn, moduleNameHashEqualFn, NULL, javaVM);
 }
 
 J9HashTable *
 hashModulePointerTableNew(J9JavaVM *javaVM, U_32 initialSize)
 {
 	U_32 flags = J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION;
-
+	
 	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, modulePointerHashFn, modulePointerHashEqualFn, NULL, javaVM);
 }
 
@@ -139,7 +143,11 @@ hashPackageTableNew(J9JavaVM *javaVM, U_32 initialSize)
 {
 	U_32 flags = J9HASH_TABLE_ALLOW_SIZE_OPTIMIZATION;
 
-	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, packageHashFn, packageHashEqualFn, NULL, javaVM);
+	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
+	if (IS_COLD_RUN(javaVM)) {
+		privatePortLibrary = OMRPORT_FROM_IMAGE();
+	}
+	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, packageHashFn, packageHashEqualFn, NULL, javaVM);
 }
 
 J9HashTable *

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -193,6 +193,9 @@ allocateClassLoader(J9JavaVM *javaVM)
 			freeClassLoader(classLoader, javaVM, NULL, TRUE);
 			classLoader = NULL;
 		} else {
+			if (IS_COLD_RUN(javaVM)) {
+				registerClassLoader(classLoader);
+			}
 			TRIGGER_J9HOOK_VM_CLASS_LOADER_CREATED(javaVM->hookInterface, javaVM, classLoader);
 		}
 	}

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -784,3 +784,7 @@ TraceEntry=Trc_VM_ReadImageFromFile_Entry NoEnv Overhead=1 Level=1 Template="Hea
 TraceExit=Trc_VM_ReadImageFromFile_Exit NoEnv Overhead=1 Level=1 Template="JVMImage Read Successful"
 TraceEntry=Trc_VM_WriteImageToFile_Entry NoEnv Overhead=1 Level=1 Template="Heap = %p. File being written to = %s"
 TraceExit=Trc_VM_WriteImageToFile_Exit NoEnv Overhead=1 Level=1 Template="JVMImage Write Successful"
+TraceEntry=Trc_VM_SubAllocateImageMemory_Entry NoEnv Overhead=1 Level=1 Template="JVMImage instance = %p. JVMImage Data = % p. Byte amount = %d."
+TraceExit=Trc_VM_SubAllocateImageMemory_Exit NoEnv Overhead=1 Level=1 Template="Memory allocated = %p."
+TraceEntry=Trc_VM_RegisterInTable_Entry NoEnv Overhead=1 Level=1 Template="Table = %p. Current size of table is %d. Last element in table is %d. Entry to be added is %d."
+TraceExit=Trc_VM_RegisterInTable_Exit NoEnv Overhead=1 Level=1 Template="Table = %p. Current size of table is %d. Last element in table is %d."

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2091,11 +2091,23 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 				goto _error;
 			}
 
-			if (NULL == (vm->classLoadingStackPool = pool_new(sizeof(J9ClassLoadingStackElement),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(vm->portLibrary))))
-				goto _error;
+			//TODO: Load if Warm run
+			if (IS_COLD_RUN(vm)) {
+				if (NULL == (vm->classLoadingStackPool = pool_new(sizeof(J9ClassLoadingStackElement), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(OMRPORT_FROM_IMAGE()))))
+					goto _error;
 
-			if (NULL == (vm->classLoaderBlocks = pool_new(sizeof(J9ClassLoader),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(vm->portLibrary))))
-				goto _error;
+				if (NULL == (vm->classLoaderBlocks = pool_new(sizeof(J9ClassLoader), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(OMRPORT_FROM_IMAGE()))))
+					goto _error;
+			}
+			else {
+				if (NULL == (vm->classLoadingStackPool = pool_new(sizeof(J9ClassLoadingStackElement), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(vm->portLibrary))))
+					goto _error;
+
+				if (NULL == (vm->classLoaderBlocks = pool_new(sizeof(J9ClassLoader), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(vm->portLibrary))))
+					goto _error;
+			}
+			
+
 			if (J2SE_VERSION(vm) >= J2SE_V11) {
 				vm->modularityPool = pool_new(OMR_MAX(sizeof(J9Package),sizeof(J9Module)),  0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_MODULES, POOL_FOR_PORT(vm->portLibrary));
 				if (NULL == vm->modularityPool) {


### PR DESCRIPTION
- Created table structure to register classloader, classpath, class segment
- Registering functions exposed
- Allocated classloaders and hashtables inside heap structure
- Registered class loaders
- ImageTableHeaders with SRP to table locations
- JVMImageData structure to dump image
- Error handling using Enums for exposed functions
- Modified Cmakelists
- Increased initial size of heap
- Trace points for registering and suballocation

Signed-off-by: Akshay Ben akshayben@ibm.com