### PR TITLE
Place JVMImage instance into JVMImagePortLibrary

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5056,6 +5056,7 @@ typedef struct J9JavaVM {
 	struct J9PortLibrary * portLibrary;
 	UDATA j2seVersion;
 	void* zipCachePool;
+	void* jvmImagePortLibrary;
 	char* ramStateFilePath;
 	struct J9VMInterface vmInterface;
 	struct HarmonyVMInterface harmonyVMInterface;

--- a/runtime/oti/jvmimage.h
+++ b/runtime/oti/jvmimage.h
@@ -25,7 +25,13 @@
 
 #define IS_WARM_RUN(javaVM) J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN)
 #define IS_COLD_RUN(javaVM) J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_COLD_RUN)
-#define OMRPORT_FROM_IMAGE() getImagePortLibrary()
+
+#define JVMIMAGEPORT_FROM_PORT(_portLibrary) ((JVMImagePortLibrary *)(_portLibrary))
+#define JVMIMAGEPORT_FROM_JAVAVM(javaVM) ((JVMImagePortLibrary *)(javaVM->jvmImagePortLibrary))
+#define IMAGEPORT_FROM_JAVAVM(javaVM) ((OMRPortLibrary *)(javaVM->jvmImagePortLibrary))
+
+#define IMAGE_ACCESS_FROM_PORT(_portLibrary) JVMImage *jvmImage = (JVMImage *)(JVMIMAGEPORT_FROM_PORT(_portLibrary)->jvmImage)
+#define IMAGE_ACCESS_FROM_JAVAVM(javaVM) JVMImage *jvmImage = (JVMImage *)(JVMIMAGEPORT_FROM_JAVAVM(javaVM)->jvmImage)
 
 #define INITIAL_CLASSLOADER_TABLE_SIZE 3
 #define INITIAL_CLASS_TABLE_SIZE 10
@@ -38,8 +44,18 @@ enum ImageRC {
 };
 
 /* forward struct declarations */
+struct JVMImagePortLibrary;
 struct ImageTableHeader;
 struct JVMImageHeader;
+
+/*
+* OMR port library wrapper 
+* JVMImage instance to access image functions
+*/
+typedef struct JVMImagePortLibrary {
+	OMRPortLibrary portLibrary;
+	void *jvmImage;
+} JVMImagePortLibrary;
 
 /*
  * allows us to dump this struct into file and reload easier

--- a/runtime/oti/jvmimage_api.h
+++ b/runtime/oti/jvmimage_api.h
@@ -38,7 +38,7 @@ extern "C" {
 *
 * @return pointer to allocated memory on success, NULL on failure 
 */
-void* mem_allocate_memory(uintptr_t byteAmount);
+void* mem_allocate_memory(J9JavaVM *javaVM, uintptr_t byteAmount);
 
 /*
 * Allocate memory in heap image
@@ -55,9 +55,10 @@ void* image_mem_allocate_memory(struct OMRPortLibrary *portLibrary, uintptr_t by
 /*
 * Free memory in heap image
 *
+* @param javaVM[in] the java vm
 * @param memoryPointer[in] pointer to address for free
 */
-void mem_free_memory(void *memoryPointer);
+void mem_free_memory(J9JavaVM *javaVM, void *memoryPointer);
 
 /*
 * Free memory in heap image
@@ -70,67 +71,65 @@ void image_mem_free_memory(struct OMRPortLibrary *portLibrary, void *memoryPoint
 /*
 * Creates and allocates the jvm image and its' heap
 *
-* @param vm[in] the java vm 
+* @param javaVM[in] the java vm 
 *
 * @return 0 on fail, 1 on success
 */
-UDATA initializeJVMImage(J9JavaVM *vm);
+UDATA initializeJVMImage(J9JavaVM *javaVM);
 
 /*
 * Registers class loader in table
 *
+* @param javaVM[in] the java vm
 * @param classLoader[in] J9ClassLoader to register
 */
-void registerClassLoader(J9ClassLoader *classLoader);
+void registerClassLoader(J9JavaVM *javaVM, J9ClassLoader *classLoader);
 
 /*
 * Registers class segment in table
 *
+* @param javaVM[in] the java vm
 * @param clazz[in] J9Class to register
 */
-void registerClassSegment(J9Class *clazz);
+void registerClassSegment(J9JavaVM *javaVM, J9Class *clazz);
 
 /*
 * Registers class path entry in table
 *
+* @param javaVM[in] the java vm
 * @param cpEntry[in] J9ClassPathEntry to register
 */
-void registerCPEntry(J9ClassPathEntry *cpEntry);
+void registerCPEntry(J9JavaVM *javaVM, J9ClassPathEntry *cpEntry);
 
 /*
 * Deregisters class loader from table
 *
+* @param javaVM[in] the java vm
 * @param classLoader[in] J9ClassLoader to register
 */
-void deregisterClassLoader(J9ClassLoader *classLoader);
+void deregisterClassLoader(J9JavaVM *javaVM, J9ClassLoader *classLoader);
 
 /*
 * Deregisters class segment from table
 *
+* @param javaVM[in] the java vm
 * @param clazz[in] J9Class to register
 */
-void deregisterClassSegment(J9Class *clazz);
+void deregisterClassSegment(J9JavaVM *javaVM, J9Class *clazz);
 
 /*
 * Deregisters class path entry from table
 *
+* @param javaVM[in] the java vm
 * @param cpEntry[in] J9ClassPathEntry to register
 */
-void deregisterCPEntry(J9ClassPathEntry *cpEntry);
-
-/*
-* Returns the port library used by the image
-* Do not use directly but through macro defined in jvmimage.h
-*
-* @return pointer to port library of image on success, NULL on failure
-*/
-OMRPortLibrary* getImagePortLibrary(void);
+void deregisterCPEntry(J9JavaVM *javaVM, J9ClassPathEntry *cpEntry);
 
 /*
 * Shut down sequence of JVMImage
 * Frees memory of heap variables and jvmimage instance
 *
-* @param vm[in] the java vm 
+* @param javaVM[in] the java vm 
 */
 void shutdownJVMImage(J9JavaVM *vm);
 

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -320,7 +320,7 @@ JVMImage::readImageFromFile(void)
 {
 	Trc_VM_ReadImageFromFile_Entry(_heap, _dumpFileName);
 
-	OMRPortLibrary* portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
+	OMRPortLibrary *portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
 	intptr_t fileDescriptor = omrfile_open(_dumpFileName, EsOpenRead, 0444);
@@ -353,7 +353,7 @@ JVMImage::writeImageToFile(void)
 {
 	Trc_VM_WriteImageToFile_Entry(_heap, _dumpFileName);
 
-	OMRPortLibrary* portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
+	OMRPortLibrary *portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
 	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
 	omrthread_monitor_enter(_jvmImageMonitor);
@@ -384,7 +384,6 @@ setupJVMImagePortLibrary(J9JavaVM *javaVM)
 	JVMImagePortLibrary *jvmImagePortLibrary = (JVMImagePortLibrary*)j9mem_allocate_memory(sizeof(JVMImagePortLibrary), OMRMEM_CATEGORY_PORT_LIBRARY);
 
 	OMRPORT_ACCESS_FROM_J9PORT(javaVM->portLibrary);
-	memset(&(jvmImagePortLibrary->portLibrary), 0, sizeof(OMRPortLibrary));
 	memcpy(&(jvmImagePortLibrary->portLibrary), privateOmrPortLibrary, sizeof(OMRPortLibrary));
 	jvmImagePortLibrary->portLibrary.mem_allocate_memory = image_mem_allocate_memory;
 	jvmImagePortLibrary->portLibrary.mem_free_memory = image_mem_free_memory;

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -24,7 +24,6 @@
 
 #include <sys/mman.h>
 
-JVMImage *JVMImage::_jvmInstance = NULL;
 const UDATA JVMImage::INITIAL_HEAP_SIZE = 1024 * 1024; /* TODO: reallocation will fail so initial heap size is large (Should be 8 byte aligned) */
 const UDATA JVMImage::INITIAL_IMAGE_SIZE = sizeof(JVMImageHeader) + JVMImage::INITIAL_HEAP_SIZE;
 
@@ -33,15 +32,6 @@ JVMImage::JVMImage(J9JavaVM *javaVM) :
 	_jvmImageHeader(NULL),
 	_heap(NULL)
 {
-	PORT_ACCESS_FROM_JAVAVM(javaVM);
-	_portLibrary = (OMRPortLibrary *) j9mem_allocate_memory(sizeof(OMRPortLibrary), OMRMEM_CATEGORY_PORT_LIBRARY);
-
-	OMRPORT_ACCESS_FROM_J9PORT(javaVM->portLibrary);
-	memset(_portLibrary, 0, sizeof(OMRPortLibrary));
-	memcpy(_portLibrary, privateOmrPortLibrary, sizeof(OMRPortLibrary));
-	_portLibrary->mem_allocate_memory = image_mem_allocate_memory;
-	_portLibrary->mem_free_memory = image_mem_free_memory;
-
 	_dumpFileName = javaVM->ramStateFilePath;
 	_isWarmRun = J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN);
 }
@@ -51,8 +41,6 @@ JVMImage::~JVMImage()
 	PORT_ACCESS_FROM_JAVAVM(_vm);
 
 	j9mem_free_memory((void*)_jvmImageHeader);
-	j9mem_free_memory((void*)_portLibrary);
-	_jvmInstance = NULL;
 }
 
 bool
@@ -76,18 +64,12 @@ JVMImage::createInstance(J9JavaVM *vm)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	_jvmInstance = (JVMImage *)j9mem_allocate_memory(sizeof(JVMImage), J9MEM_CATEGORY_CLASSES);
-	if (NULL != _jvmInstance) {
-		new(_jvmInstance) JVMImage(vm);   
+	JVMImage *jvmInstance = (JVMImage *)j9mem_allocate_memory(sizeof(JVMImage), J9MEM_CATEGORY_CLASSES);
+	if (NULL != jvmInstance) {
+		new(jvmInstance) JVMImage(vm);
 	}
 
-	return _jvmInstance;
-}
-
-JVMImage *
-JVMImage::getInstance(void)
-{
-	return _jvmInstance;
+	return jvmInstance;
 }
 
 /* TODO: This will be expanded once warm run set up is finished */
@@ -218,15 +200,16 @@ JVMImage::reallocateTable(ImageTableHeader *table, uintptr_t tableSize)
 void *
 JVMImage::subAllocateMemory(uintptr_t byteAmount)
 {
-	Trc_VM_SubAllocateImageMemory_Entry(_jvmInstance, _jvmImageHeader, byteAmount);
+	Trc_VM_SubAllocateImageMemory_Entry(_jvmImageHeader, byteAmount);
 
 	omrthread_monitor_enter(_jvmImageMonitor);
 
-	void *memStart = _portLibrary->heap_allocate(_portLibrary, _heap, byteAmount);	
+	OMRPortLibrary *portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
+	void *memStart = portLibrary->heap_allocate(portLibrary, _heap, byteAmount);	
 	/* image memory is not large enough and needs to be reallocated */
 	if (NULL == memStart) {
 		reallocateImageMemory(_jvmImageHeader->imageSize * 2 + byteAmount);
-		memStart = _portLibrary->heap_allocate(_portLibrary, _heap, byteAmount);
+		memStart = portLibrary->heap_allocate(portLibrary, _heap, byteAmount);
 	}
 
 	omrthread_monitor_exit(_jvmImageMonitor);
@@ -241,11 +224,12 @@ JVMImage::reallocateMemory(void *address, uintptr_t byteAmount)
 {
 	omrthread_monitor_enter(_jvmImageMonitor);
 
-	void *memStart = _portLibrary->heap_reallocate(_portLibrary, _heap, address, byteAmount);
+	OMRPortLibrary *portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
+	void *memStart = portLibrary->heap_reallocate(portLibrary, _heap, address, byteAmount);
 	/* image memory is not large enough and needs to be reallocated */
 	if (NULL == memStart) {
 		reallocateImageMemory(_jvmImageHeader->imageSize * 2 + byteAmount);
-		memStart = _portLibrary->heap_reallocate(_portLibrary, _heap, address, byteAmount);
+		memStart = portLibrary->heap_reallocate(portLibrary, _heap, address, byteAmount);
 	}
 
 	omrthread_monitor_exit(_jvmImageMonitor);
@@ -258,7 +242,8 @@ JVMImage::freeSubAllocatedMemory(void *address)
 {
 	omrthread_monitor_enter(_jvmImageMonitor);
 
-	_portLibrary->heap_free(_portLibrary, _heap, address);
+	OMRPortLibrary *portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
+	portLibrary->heap_free(portLibrary, _heap, address);
 
 	omrthread_monitor_exit(_jvmImageMonitor);
 }
@@ -335,7 +320,8 @@ JVMImage::readImageFromFile(void)
 {
 	Trc_VM_ReadImageFromFile_Entry(_heap, _dumpFileName);
 
-	OMRPORT_ACCESS_FROM_OMRPORT(getPortLibrary());
+	OMRPortLibrary* portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
+	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
 	intptr_t fileDescriptor = omrfile_open(_dumpFileName, EsOpenRead, 0444);
 	if (-1 == fileDescriptor) {
@@ -367,7 +353,8 @@ JVMImage::writeImageToFile(void)
 {
 	Trc_VM_WriteImageToFile_Entry(_heap, _dumpFileName);
 
-	OMRPORT_ACCESS_FROM_OMRPORT(getPortLibrary());
+	OMRPortLibrary* portLibrary = IMAGEPORT_FROM_JAVAVM(_vm);
+	OMRPORT_ACCESS_FROM_OMRPORT(portLibrary);
 
 	omrthread_monitor_enter(_jvmImageMonitor);
 
@@ -390,20 +377,39 @@ JVMImage::writeImageToFile(void)
 	return true;
 }
 
-extern "C" UDATA
-initializeJVMImage(J9JavaVM *vm)
+JVMImagePortLibrary * 
+setupJVMImagePortLibrary(J9JavaVM *javaVM)
 {
-	JVMImage *jvmImage = JVMImage::createInstance(vm);
-	if (NULL == jvmImage) {
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+	JVMImagePortLibrary *jvmImagePortLibrary = (JVMImagePortLibrary*)j9mem_allocate_memory(sizeof(JVMImagePortLibrary), OMRMEM_CATEGORY_PORT_LIBRARY);
+
+	OMRPORT_ACCESS_FROM_J9PORT(javaVM->portLibrary);
+	memset(&(jvmImagePortLibrary->portLibrary), 0, sizeof(OMRPortLibrary));
+	memcpy(&(jvmImagePortLibrary->portLibrary), privateOmrPortLibrary, sizeof(OMRPortLibrary));
+	jvmImagePortLibrary->portLibrary.mem_allocate_memory = image_mem_allocate_memory;
+	jvmImagePortLibrary->portLibrary.mem_free_memory = image_mem_free_memory;
+	jvmImagePortLibrary->jvmImage = NULL;
+
+	return jvmImagePortLibrary;
+}
+
+extern "C" UDATA
+initializeJVMImage(J9JavaVM *javaVM)
+{
+	JVMImagePortLibrary *jvmImagePortLibrary = setupJVMImagePortLibrary(javaVM);
+	JVMImage *jvmImage = JVMImage::createInstance(javaVM);
+	if (NULL == jvmImagePortLibrary || NULL == jvmImage) {
 		goto _error;
 	}
+	javaVM->jvmImagePortLibrary = jvmImagePortLibrary;
+	jvmImagePortLibrary->jvmImage = jvmImage;
 
-	if (IS_COLD_RUN(vm)
+	if (IS_COLD_RUN(javaVM)
 		&& (IMAGE_ERROR == jvmImage->setupColdRun())) {
 		goto _error;
 	}
 
-	if(IS_WARM_RUN(vm)
+	if(IS_WARM_RUN(javaVM)
 		&& (IMAGE_ERROR == jvmImage->setupWarmRun())) {
 		goto _error;
 	}
@@ -411,14 +417,14 @@ initializeJVMImage(J9JavaVM *vm)
 	return 1;
 
 _error:
-	shutdownJVMImage(vm);
+	shutdownJVMImage(javaVM);
 	return 0;
 }
 
 extern "C" void
-registerClassLoader(J9ClassLoader *classLoader)
+registerClassLoader(J9JavaVM *javaVM, J9ClassLoader *classLoader)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	Assert_VM_notNull(jvmImage);
 
@@ -426,9 +432,9 @@ registerClassLoader(J9ClassLoader *classLoader)
 }
 
 extern "C" void
-registerClassSegment(J9Class *clazz)
+registerClassSegment(J9JavaVM *javaVM, J9Class *clazz)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	Assert_VM_notNull(jvmImage);
 
@@ -436,9 +442,9 @@ registerClassSegment(J9Class *clazz)
 }
 
 extern "C" void
-registerCPEntry(J9ClassPathEntry *cpEntry)
+registerCPEntry(J9JavaVM *javaVM, J9ClassPathEntry *cpEntry)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	Assert_VM_notNull(jvmImage);
 	
@@ -446,9 +452,9 @@ registerCPEntry(J9ClassPathEntry *cpEntry)
 }
 
 extern "C" void
-deregisterClassLoader(J9ClassLoader *classLoader)
+deregisterClassLoader(J9JavaVM *javaVM, J9ClassLoader *classLoader)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	Assert_VM_notNull(jvmImage);
 
@@ -456,9 +462,9 @@ deregisterClassLoader(J9ClassLoader *classLoader)
 }
 
 extern "C" void
-deregisterClassSegment(J9Class *clazz)
+deregisterClassSegment(J9JavaVM *javaVM, J9Class *clazz)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	Assert_VM_notNull(jvmImage);
 
@@ -466,68 +472,56 @@ deregisterClassSegment(J9Class *clazz)
 }
 
 extern "C" void
-deregisterCPEntry(J9ClassPathEntry *cpEntry)
+deregisterCPEntry(J9JavaVM *javaVM, J9ClassPathEntry *cpEntry)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	Assert_VM_notNull(jvmImage);
 
 	jvmImage->deregisterEntryInTable(jvmImage->getClassPathEntryTable(), (UDATA)cpEntry);
 }
 
-extern "C" OMRPortLibrary *
-getImagePortLibrary(void)
-{
-	JVMImage *jvmImage = JVMImage::getInstance();
-
-	if (NULL == jvmImage) {
-		return NULL;
-	}
-
-	return jvmImage->getPortLibrary();
-}
-
 extern "C" void
-shutdownJVMImage(J9JavaVM *vm)
+shutdownJVMImage(J9JavaVM *javaVM)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	if (NULL != jvmImage) {
-		PORT_ACCESS_FROM_JAVAVM(vm);
+		PORT_ACCESS_FROM_JAVAVM(javaVM);
 
 		jvmImage->destroyMonitor();
 		jvmImage->~JVMImage();
 		j9mem_free_memory(jvmImage);
+		j9mem_free_memory(JVMIMAGEPORT_FROM_JAVAVM(javaVM));
+		javaVM->jvmImagePortLibrary = NULL;
 	}
 }
 
 extern "C" void *
 image_mem_allocate_memory(struct OMRPortLibrary *portLibrary, uintptr_t byteAmount, const char *callSite, uint32_t category)
 {
-	void *pointer = NULL;
-	
-	JVMImage *jvmImage = JVMImage::getInstance();
-	pointer = jvmImage->subAllocateMemory(byteAmount);
+	IMAGE_ACCESS_FROM_PORT(portLibrary);
+
+	void *pointer = jvmImage->subAllocateMemory(byteAmount);
 	return pointer;
 }
 
 extern "C" void *
-mem_allocate_memory(uintptr_t byteAmount)
+mem_allocate_memory(J9JavaVM *javaVM, uintptr_t byteAmount)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
-	return image_mem_allocate_memory(jvmImage->getPortLibrary(), byteAmount, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES);
+	return image_mem_allocate_memory(IMAGEPORT_FROM_JAVAVM(javaVM), byteAmount, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES);
 }
 
 extern "C" void
 image_mem_free_memory(struct OMRPortLibrary *portLibrary, void *memoryPointer)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
+	IMAGE_ACCESS_FROM_PORT(portLibrary);
+
 	jvmImage->freeSubAllocatedMemory(memoryPointer);
 }
 
 extern "C" void
-mem_free_memory(void *memoryPointer)
+mem_free_memory(J9JavaVM *javaVM, void *memoryPointer)
 {
-	JVMImage *jvmImage = JVMImage::getInstance();
-	image_mem_free_memory(jvmImage->getPortLibrary(), memoryPointer);
+	image_mem_free_memory(IMAGEPORT_FROM_JAVAVM(javaVM), memoryPointer);
 }

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -31,20 +31,19 @@
 #include "j9protos.h"
 #include "ut_j9vm.h"
 
+#define JVMIMAGE_ACCESS_FROM_OMRPORT(omrPortLib) JVMImage *jvmImage = (JVMImage *) ((JVMImagePortLibrary *) (omrPortLib)->jvmImage)
+
 class JVMImage
 {
 	/*
 	 * Data Members
 	 */
 private:
-	static JVMImage *_jvmInstance;
-	
 	J9JavaVM *_vm;
 
 	JVMImageHeader *_jvmImageHeader;
 	J9Heap *_heap;
 
-	OMRPortLibrary *_portLibrary;
 	omrthread_monitor_t _jvmImageMonitor;
 
 	char *_dumpFileName;
@@ -65,8 +64,8 @@ private:
 	void* initializeHeap(void);
 
 	bool allocateImageTableHeaders(void);
-	void* allocateTable(ImageTableHeader* table, uintptr_t tableSize);
-	void* reallocateTable(ImageTableHeader* table, uintptr_t tableSize);
+	void* allocateTable(ImageTableHeader *table, uintptr_t tableSize);
+	void* reallocateTable(ImageTableHeader *table, uintptr_t tableSize);
 
 	bool readImageFromFile(void);
 	bool writeImageToFile(void);
@@ -77,7 +76,6 @@ public:
 	~JVMImage();
 
 	static JVMImage* createInstance(J9JavaVM *javaVM);
-	static JVMImage* getInstance(void);
 
 	ImageRC setupWarmRun(void);
 	ImageRC setupColdRun(void);
@@ -87,12 +85,11 @@ public:
 	void freeSubAllocatedMemory(void *memStart); /* TODO: Extension functions for heap (not used currently) */
 
 	void registerEntryInTable(ImageTableHeader *table, UDATA entry);
-	void deregisterEntryInTable(ImageTableHeader* table, UDATA entry);
-	UDATA* findEntryInTable(ImageTableHeader* table, UDATA entry);
+	void deregisterEntryInTable(ImageTableHeader *table, UDATA entry);
+	UDATA* findEntryInTable(ImageTableHeader *table, UDATA entry);
 
 	void destroyMonitor(void);
 
-	OMRPortLibrary* getPortLibrary(void) { return _portLibrary; }
 	ImageTableHeader* getClassLoaderTable(void) { return WSRP_GET(_jvmImageHeader->classLoaderTable, ImageTableHeader*); }
 	ImageTableHeader* getClassSegmentTable(void) { return WSRP_GET(_jvmImageHeader->classSegmentTable, ImageTableHeader*); }
 	ImageTableHeader* getClassPathEntryTable(void) { return WSRP_GET(_jvmImageHeader->classPathEntryTable, ImageTableHeader*); }

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -271,7 +271,7 @@ hashClassTableNew(J9JavaVM *javaVM, U_32 initialSize)
 
 	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
 	if (IS_COLD_RUN(javaVM)) {
-		privatePortLibrary = OMRPORT_FROM_IMAGE();
+		privatePortLibrary = IMAGEPORT_FROM_JAVAVM(javaVM);
 	}
 	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(KeyHashTableClassEntry), sizeof(char *), flags, J9MEM_CATEGORY_CLASSES, classHashFn, classHashEqualFn, NULL, javaVM);
 }
@@ -552,7 +552,7 @@ hashClassLocationTableNew(J9JavaVM *javaVM, U_32 initialSize)
 
 	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
 	if (IS_COLD_RUN(javaVM)) {
-		privatePortLibrary = OMRPORT_FROM_IMAGE();
+		privatePortLibrary = IMAGEPORT_FROM_JAVAVM(javaVM);
 	}
 	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(J9ClassLocation), sizeof(char *), flags, J9MEM_CATEGORY_CLASSES, classLocationHashFn, classLocationHashEqualFn, NULL, javaVM);
 }

--- a/runtime/vm/ModularityHashTables.c
+++ b/runtime/vm/ModularityHashTables.c
@@ -125,7 +125,7 @@ hashModuleNameTableNew(J9JavaVM *javaVM, U_32 initialSize)
 
 	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
 	if (IS_COLD_RUN(javaVM)) {
-		privatePortLibrary = OMRPORT_FROM_IMAGE();
+		privatePortLibrary = IMAGEPORT_FROM_JAVAVM(javaVM);
 	}
 	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, moduleNameHashFn, moduleNameHashEqualFn, NULL, javaVM);
 }
@@ -145,7 +145,7 @@ hashPackageTableNew(J9JavaVM *javaVM, U_32 initialSize)
 
 	OMRPortLibrary* privatePortLibrary = OMRPORT_FROM_J9PORT(javaVM->portLibrary);
 	if (IS_COLD_RUN(javaVM)) {
-		privatePortLibrary = OMRPORT_FROM_IMAGE();
+		privatePortLibrary = IMAGEPORT_FROM_JAVAVM(javaVM);
 	}
 	return hashTableNew(privatePortLibrary, J9_GET_CALLSITE(), initialSize, sizeof(void*), sizeof(void*), flags, J9MEM_CATEGORY_MODULES, packageHashFn, packageHashEqualFn, NULL, javaVM);
 }

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -194,7 +194,7 @@ allocateClassLoader(J9JavaVM *javaVM)
 			classLoader = NULL;
 		} else {
 			if (IS_COLD_RUN(javaVM)) {
-				registerClassLoader(classLoader);
+				registerClassLoader(javaVM, classLoader);
 			}
 			TRIGGER_J9HOOK_VM_CLASS_LOADER_CREATED(javaVM->hookInterface, javaVM, classLoader);
 		}
@@ -413,7 +413,7 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
 	if (IS_COLD_RUN(javaVM)) {
-		deregisterClassLoader(classLoader);
+		deregisterClassLoader(javaVM, classLoader);
 	}
 	pool_removeElement(javaVM->classLoaderBlocks, classLoader);
 

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -784,7 +784,7 @@ TraceEntry=Trc_VM_ReadImageFromFile_Entry NoEnv Overhead=1 Level=1 Template="Hea
 TraceExit=Trc_VM_ReadImageFromFile_Exit NoEnv Overhead=1 Level=1 Template="JVMImage Read Successful"
 TraceEntry=Trc_VM_WriteImageToFile_Entry NoEnv Overhead=1 Level=1 Template="Heap = %p. File being written to = %s"
 TraceExit=Trc_VM_WriteImageToFile_Exit NoEnv Overhead=1 Level=1 Template="JVMImage Write Successful"
-TraceEntry=Trc_VM_SubAllocateImageMemory_Entry NoEnv Overhead=1 Level=1 Template="JVMImage instance = %p. JVMImage Data = % p. Byte amount = %d."
+TraceEntry=Trc_VM_SubAllocateImageMemory_Entry NoEnv Overhead=1 Level=1 Template="JVMImage Data = % p. Byte amount = %d."
 TraceExit=Trc_VM_SubAllocateImageMemory_Exit NoEnv Overhead=1 Level=1 Template="Memory allocated = %p."
 TraceEntry=Trc_VM_RegisterInTable_Entry NoEnv Overhead=1 Level=1 Template="Table = %p. Current size of table is %d. Last element in table is %d. Entry to be added is %d."
 TraceExit=Trc_VM_RegisterInTable_Exit NoEnv Overhead=1 Level=1 Template="Table = %p. Current size of table is %d. Last element in table is %d."

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2092,10 +2092,10 @@ IDATA VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved) {
 
 			/* TODO: Load if Warm run */
 			if (IS_COLD_RUN(vm)) {
-				if (NULL == (vm->classLoadingStackPool = pool_new(sizeof(J9ClassLoadingStackElement), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(OMRPORT_FROM_IMAGE())))) {
+				if (NULL == (vm->classLoadingStackPool = pool_new(sizeof(J9ClassLoadingStackElement), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(IMAGEPORT_FROM_JAVAVM(vm))))) {
 					goto _error;
 				}
-				if (NULL == (vm->classLoaderBlocks = pool_new(sizeof(J9ClassLoader), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(OMRPORT_FROM_IMAGE())))) {
+				if (NULL == (vm->classLoaderBlocks = pool_new(sizeof(J9ClassLoader), 0, 0, 0, J9_GET_CALLSITE(), J9MEM_CATEGORY_CLASSES, POOL_FOR_PORT(IMAGEPORT_FROM_JAVAVM(vm))))) {
 					goto _error;
 				}
 			} else {


### PR DESCRIPTION
- created wrapper around omr port library and added jvmimage
- placed pointer to wrapper in J9JavaVM
- changed all functions to rely on vm reference or jvmimageportlibrary

Signed-off-by: akshayben akshayben@ibm.com