### PR TITLE
Made jvmImageHeader aligned to Page Size

### DIFF
--- a/runtime/oti/jvmimage.h
+++ b/runtime/oti/jvmimage.h
@@ -23,6 +23,10 @@
 #ifndef jvmimage_h
 #define jvmimage_h
 
+#define PAGE_SIZE 4096
+#define PAGE_SIZE_MASK (PAGE_SIZE - 1)
+#define PAGE_SIZE_ALIGNED_ADDRESS(address) (void *) (((uintptr_t) (address) + PAGE_SIZE_MASK) & (~PAGE_SIZE_MASK))
+
 #define IS_WARM_RUN(javaVM) J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN)
 #define IS_COLD_RUN(javaVM) J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_COLD_RUN)
 
@@ -47,6 +51,7 @@ struct JVMImageHeader;
 typedef struct JVMImageHeader {
 	UDATA imageSize; /* image size in bytes */
 	uintptr_t imageAddress;
+	uintptr_t imageAlignedAddress;
 	J9WSRP classLoaderTable;
 	J9WSRP classTable;
 	J9WSRP classPathEntryTable;

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -51,7 +51,6 @@ private:
 	bool _isWarmRun;
 protected:
 public:
-	static const UDATA INITIAL_HEAP_SIZE;
 	static const UDATA INITIAL_IMAGE_SIZE;
 	
 	/*


### PR DESCRIPTION
- added alignedMemory ref in jvmImageHeader
- offset jvmImageHeader to be aligned
- set MAP_FIXED flag for mmap (needs to be page aligned)
- fixed bug on write

Signed-off-by: akshayben akshayben@ibm.com