### PR TITLE
Registering Class Path Entries For fixup

### DIFF
--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -359,6 +359,19 @@ JVMImage::fixupClasses(void)
 	}
 }
 
+void
+JVMImage::fixupClassPathEntries(void)
+{
+	J9ClassPathEntry *currentCPEntry = (J9ClassPathEntry *) imageTableStartDo(getClassPathEntryTable());
+
+	while (NULL != currentCPEntry) {
+		currentCPEntry->type = CPE_TYPE_UNKNOWN;
+		currentCPEntry->status = 0;
+
+		currentCPEntry = (J9ClassPathEntry *) imageTableNextDo(getClassPathEntryTable());
+	}
+}
+
 bool
 JVMImage::readImageFromFile(void)
 {
@@ -424,6 +437,7 @@ JVMImage::teardownImage(void)
 {
 	fixupClassLoaders();
 	fixupClasses();
+	fixupClassPathEntries();
 	writeImageToFile();
 }
 

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -71,6 +71,7 @@ private:
 
 	void fixupClassLoaders(void);
 	void fixupClasses(void);
+	void fixupClassPathEntries(void);
 protected:
 	void *operator new(size_t size, void *memoryPointer) { return memoryPointer; }
 public:

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1345,6 +1345,9 @@ initializeClassPath(J9JavaVM *vm, char *classPath, U_8 classPathSeparator, U_16 
 						initializeClassPathEntry(vm, cpEntry);
 					}
 					cpPathMemory += (cpEntry->pathLength + 1);
+					if (IS_COLD_RUN(vm)) {
+						registerCPEntry(vm, cpEntry);
+					}
 					cpEntry++;
 					i++;
 				}


### PR DESCRIPTION
- created fixup function for class path Entries
- fixup sets type to unknown
- registers class path entries in jvminit

Signed-off-by: akshayben <akshayben@ibm.com>