### PR TITLE
Fixed Teardown sequence.

### DIFF
--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -397,7 +397,7 @@ internalInitializeJavaLangClassLoader(JNIEnv * env)
 
 		/* set app class loader if warm run */
 		if (IS_WARM_RUN(vm)) {
-			vm->applicationClassLoader = vmFuncs->findClassLoader(vm, IMAGE_CATEGORY_APP_CLASSLOADER);	
+			vm->applicationClassLoader = vmFuncs->findClassLoader(vm, IMAGE_CATEGORY_APP_CLASSLOADER);
 		}
 		/* fall back on allocation if find fails */
 		if (NULL == vm->applicationClassLoader) {

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -434,14 +434,12 @@ internalInitializeJavaLangClassLoader(JNIEnv * env)
 			if (IS_WARM_RUN(vm)) {
 				vm->extensionClassLoader = vmFuncs->findClassLoader(vm, IMAGE_CATEGORY_EXTENSION_CLASSLOADER);
 			}
-
 			/* fall back on allocation if find fails */
 			if (NULL == vm->extensionClassLoader) {
 				vm->extensionClassLoader = (void*)(UDATA)(vmFuncs->internalAllocateClassLoader(vm, classLoaderObject));
 			} else {
 				vmFuncs->initializeImageClassLoaderObject(vm, vm->extensionClassLoader, classLoaderObject);
 			}
-
 			if (NULL != vmThread->currentException) {
 				/* while this exception check and return statement seem un-necessary, it is added to prevent
 				 * oversights if anybody adds more code in the future.

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -397,11 +397,13 @@ internalInitializeJavaLangClassLoader(JNIEnv * env)
 
 		/* set app class loader if warm run */
 		if (IS_WARM_RUN(vm)) {
-			vm->applicationClassLoader = vmFuncs->findClassLoader(vm, IMAGE_CATEGORY_APP_CLASSLOADER);
+			vm->applicationClassLoader = vmFuncs->findClassLoader(vm, IMAGE_CATEGORY_APP_CLASSLOADER);	
 		}
 		/* fall back on allocation if find fails */
 		if (NULL == vm->applicationClassLoader) {
 			vm->applicationClassLoader = (void*)(UDATA)(vmFuncs->internalAllocateClassLoader(vm, J9_JNI_UNWRAP_REFERENCE(appClassLoader)));
+		} else {
+			vmFuncs->initializeImageClassLoaderObject(vm, vm->applicationClassLoader, J9_JNI_UNWRAP_REFERENCE(appClassLoader));
 		}
 		
 		if (NULL != vmThread->currentException) {
@@ -432,10 +434,14 @@ internalInitializeJavaLangClassLoader(JNIEnv * env)
 			if (IS_WARM_RUN(vm)) {
 				vm->extensionClassLoader = vmFuncs->findClassLoader(vm, IMAGE_CATEGORY_EXTENSION_CLASSLOADER);
 			}
+
 			/* fall back on allocation if find fails */
 			if (NULL == vm->extensionClassLoader) {
 				vm->extensionClassLoader = (void*)(UDATA)(vmFuncs->internalAllocateClassLoader(vm, classLoaderObject));
+			} else {
+				vmFuncs->initializeImageClassLoaderObject(vm, vm->extensionClassLoader, classLoaderObject);
 			}
+
 			if (NULL != vmThread->currentException) {
 				/* while this exception check and return statement seem un-necessary, it is added to prevent
 				 * oversights if anybody adds more code in the future.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4788,6 +4788,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *deregisterClass)(struct J9JavaVM *javaVM, struct J9Class *clazz);
 	void ( *deregisterCPEntry)(struct J9JavaVM *javaVM, struct J9ClassPathEntry *cpEntry);
 	J9ClassLoader* (*findClassLoader)(struct J9JavaVM* javaVM, uint32_t classLoaderCategory);
+	void (*initializeImageClassLoaderObject)(struct J9JavaVM* javaVM, struct J9ClassLoader* classLoader, j9object_t classLoaderObject);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4787,8 +4787,8 @@ typedef struct J9InternalVMFunctions {
 	void ( *registerCPEntry)(struct J9JavaVM *javaVM, struct J9ClassPathEntry *cpEntry);
 	void ( *deregisterClass)(struct J9JavaVM *javaVM, struct J9Class *clazz);
 	void ( *deregisterCPEntry)(struct J9JavaVM *javaVM, struct J9ClassPathEntry *cpEntry);
-	J9ClassLoader* (*findClassLoader)(struct J9JavaVM* javaVM, uint32_t classLoaderCategory);
-	void (*initializeImageClassLoaderObject)(struct J9JavaVM* javaVM, struct J9ClassLoader* classLoader, j9object_t classLoaderObject);
+	J9ClassLoader* (*findClassLoader)(struct J9JavaVM *javaVM, uint32_t classLoaderCategory);
+	void (*initializeImageClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/jvmimage_api.h
+++ b/runtime/oti/jvmimage_api.h
@@ -138,6 +138,15 @@ UDATA* findEntryLocationInTable(ImageTableHeader *table, UDATA entry);
 J9ClassLoader* findClassLoader(J9JavaVM *javaVM, uint32_t classLoaderCategory);
 
 /*
+* Initializes class loader object. Mimics behavious of internalAllocateClassLoader
+*
+* @param javaVM[in] the java vm
+* @param classLoader the class loader
+* @param classLoaderObject unwrapped class loader object ref
+*/
+void initializeImageClassLoaderObject(J9JavaVM* javaVM, J9ClassLoader* classLoader, j9object_t classLoaderObject);
+
+/*
 * Shut down sequence of JVMImage
 * Frees memory of heap variables and jvmimage instance
 *

--- a/runtime/oti/jvmimage_api.h
+++ b/runtime/oti/jvmimage_api.h
@@ -138,13 +138,13 @@ UDATA* findEntryLocationInTable(ImageTableHeader *table, UDATA entry);
 J9ClassLoader* findClassLoader(J9JavaVM *javaVM, uint32_t classLoaderCategory);
 
 /*
-* Initializes class loader object. Mimics behavious of internalAllocateClassLoader
+* Initializes class loader object. Mimics behaviour of internalAllocateClassLoader
 *
 * @param javaVM[in] the java vm
 * @param classLoader the class loader
 * @param classLoaderObject unwrapped class loader object ref
 */
-void initializeImageClassLoaderObject(J9JavaVM* javaVM, J9ClassLoader* classLoader, j9object_t classLoaderObject);
+void initializeImageClassLoaderObject(J9JavaVM *javaVM, J9ClassLoader *classLoader, j9object_t classLoaderObject);
 
 /*
 * Shut down sequence of JVMImage

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -403,12 +403,12 @@ JVMImage::fixupClass(J9Class *clazz)
 
 	UDATA i;
 	if (NULL != clazz->staticSplitMethodTable) {
-		for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; ++i) {
+		for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; i++) {
 			clazz->staticSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialStaticMethod;
 		}
 	}
 	if (NULL != clazz->specialSplitMethodTable) {
-		for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; ++i) {
+		for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; i++) {
 			clazz->specialSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialSpecialMethod;
 		}
 	}
@@ -429,12 +429,12 @@ JVMImage::fixupArrayClass(J9ArrayClass *clazz)
 
 	UDATA i;
 	if (NULL != clazz->staticSplitMethodTable) {
-		for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; ++i) {
+		for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; i++) {
 			clazz->staticSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialStaticMethod;
 		}
 	}
 	if (NULL != clazz->specialSplitMethodTable) {
-		for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; ++i) {
+		for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; i++) {
 			clazz->specialSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialSpecialMethod;
 		}
 	}

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -343,6 +343,8 @@ JVMImage::fixupClassLoaders(void)
 	
 	while (NULL != currentClassLoader) {
 		currentClassLoader->sharedLibraries = NULL;
+		currentClassLoader->librariesHead = NULL;
+		currentClassLoader->librariesTail = NULL;
 		currentClassLoader->classLoaderObject = NULL;
 		currentClassLoader->unloadLink = NULL;
 		currentClassLoader->gcLinkNext = NULL;
@@ -364,15 +366,13 @@ JVMImage::fixupClasses(void)
 	J9Class *currentClass = (J9Class *) imageTableStartDo(getClassTable());
 
 	while (NULL != currentClass) {
-		currentClass->classObject = NULL;
-		currentClass->initializeStatus = J9ClassInitNotInitialized;
-		internalRunPreInitInstructions(currentClass, _vm->mainThread);
-		currentClass->jniIDs = NULL;
-		currentClass->replacedClass = NULL;
-		currentClass->callSites = NULL;
-		currentClass->methodTypes = NULL;
-		currentClass->varHandleMethodTypes = NULL;
-		currentClass->gcLink = NULL;
+		J9ROMClass *romClass = currentClass->romClass;
+		
+		if (J9ROMCLASS_IS_ARRAY(romClass)) {
+			fixupArrayClass((J9ArrayClass *) currentClass);
+		} else {
+			fixupClass(currentClass);
+		}
 
 		/* Fixup the last ITable */
 		currentClass->lastITable = (J9ITable *) currentClass->iTable;
@@ -381,6 +381,94 @@ JVMImage::fixupClasses(void)
 		}
 
 		currentClass = (J9Class *) imageTableNextDo(getClassTable());
+	}
+}
+
+void
+JVMImage::fixupClass(J9Class *clazz)
+{
+	clazz->classObject = NULL;
+	fixupMethodRunAddresses(clazz);
+	fixupConstantPool(clazz);
+	clazz->initializeStatus = J9ClassInitNotInitialized;
+	clazz->jniIDs = NULL;
+	clazz->replacedClass = NULL;
+	clazz->callSites = NULL;
+	clazz->methodTypes = NULL;
+	clazz->varHandleMethodTypes = NULL;
+	clazz->gcLink = NULL;
+
+	UDATA totalStaticSlots = totalStaticSlotsForClass(clazz->romClass);
+	memset(clazz->ramStatics, 0, totalStaticSlots * sizeof(UDATA));
+
+	UDATA i;
+	if (NULL != clazz->staticSplitMethodTable) {
+		for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; ++i) {
+			clazz->staticSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialStaticMethod;
+		}
+	}
+	if (NULL != clazz->specialSplitMethodTable) {
+		for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; ++i) {
+			clazz->specialSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialSpecialMethod;
+		}
+	}
+}
+
+void
+JVMImage::fixupArrayClass(J9ArrayClass *clazz)
+{
+	clazz->classObject = NULL;
+	fixupConstantPool((J9Class *) clazz);
+	clazz->initializeStatus = J9ClassInitSucceeded;
+	clazz->jniIDs = NULL;
+	clazz->replacedClass = NULL;
+	clazz->callSites = NULL;
+	clazz->methodTypes = NULL;
+	clazz->varHandleMethodTypes = NULL;
+	clazz->gcLink = NULL;
+
+	UDATA i;
+	if (NULL != clazz->staticSplitMethodTable) {
+		for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; ++i) {
+			clazz->staticSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialStaticMethod;
+		}
+	}
+	if (NULL != clazz->specialSplitMethodTable) {
+		for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; ++i) {
+			clazz->specialSplitMethodTable[i] = (J9Method*)_vm->initialMethods.initialSpecialMethod;
+		}
+	}
+}
+
+void
+JVMImage::fixupMethodRunAddresses(J9Class *ramClass)
+{
+	J9ROMClass *romClass = ramClass->romClass;
+
+	if (romClass->romMethodCount != 0) {
+		UDATA i;
+		UDATA count = romClass->romMethodCount;
+		J9Method* ramMethod = ramClass->ramMethods;
+		for (i = 0; i < count; i++) {
+			initializeMethodRunAddress(_vm->mainThread, ramMethod);
+			ramMethod++;
+		}
+	}
+}
+
+void
+JVMImage::fixupConstantPool(J9Class *ramClass)
+{
+	J9ROMClass *romClass = ramClass->romClass;
+	J9ConstantPool *ramCP = ((J9ConstantPool *) ramClass->ramConstantPool);
+	J9ConstantPool *ramCPWithoutHeader = ramCP + 1;
+	UDATA ramCPCount = romClass->ramConstantPoolCount;
+	UDATA ramCPCountWithoutHeader = ramCPCount - 1;
+	
+	/* Zero the ramCP and run pre init */
+	if (ramCPCount != 0) {
+		memset(ramCPWithoutHeader, 0, ramCPCountWithoutHeader * sizeof(J9RAMConstantPoolItem));
+		internalRunPreInitInstructions(ramClass, _vm->mainThread);
 	}
 }
 
@@ -585,6 +673,21 @@ findClassLoader(J9JavaVM *javaVM, uint32_t classLoaderCategory)
 }
 
 extern "C" void
+initializeImageClassLoaderObject(J9JavaVM *javaVM, J9ClassLoader *classLoader, j9object_t classLoaderObject)
+{
+	J9VMThread* vmThread = currentVMThread(javaVM);
+
+	omrthread_monitor_enter(javaVM->classLoaderBlocksMutex);
+
+	J9CLASSLOADER_SET_CLASSLOADEROBJECT(vmThread, classLoader, classLoaderObject);
+
+	issueWriteBarrier();
+	J9VMJAVALANGCLASSLOADER_SET_VMREF(vmThread, classLoaderObject, classLoader);
+	
+	omrthread_monitor_exit(javaVM->classLoaderBlocksMutex);
+}
+
+extern "C" void
 shutdownJVMImage(J9JavaVM *javaVM)
 {
 	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
@@ -600,15 +703,13 @@ shutdownJVMImage(J9JavaVM *javaVM)
 }
 
 extern "C" void
-teardownAndShutdownJVMImage(J9JavaVM *javaVM)
+teardownJVMImage(J9JavaVM *javaVM)
 {
 	IMAGE_ACCESS_FROM_JAVAVM(javaVM);
 
 	if (IS_COLD_RUN(javaVM)) {
 		jvmImage->teardownImage();
 	}
-
-	shutdownJVMImage(javaVM);
 }
 
 extern "C" void *

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -443,14 +443,15 @@ JVMImage::fixupArrayClass(J9ArrayClass *clazz)
 void
 JVMImage::fixupMethodRunAddresses(J9Class *ramClass)
 {
+	J9VMThread *vmThread = currentVMThread(javaVM);
 	J9ROMClass *romClass = ramClass->romClass;
 
 	if (romClass->romMethodCount != 0) {
 		UDATA i;
 		UDATA count = romClass->romMethodCount;
-		J9Method* ramMethod = ramClass->ramMethods;
+		J9Method *ramMethod = ramClass->ramMethods;
 		for (i = 0; i < count; i++) {
-			initializeMethodRunAddress(_vm->mainThread, ramMethod);
+			initializeMethodRunAddress(vmThread, ramMethod);
 			ramMethod++;
 		}
 	}
@@ -459,16 +460,17 @@ JVMImage::fixupMethodRunAddresses(J9Class *ramClass)
 void
 JVMImage::fixupConstantPool(J9Class *ramClass)
 {
+	J9VMThread *vmThread = currentVMThread(javaVM);
 	J9ROMClass *romClass = ramClass->romClass;
 	J9ConstantPool *ramCP = ((J9ConstantPool *) ramClass->ramConstantPool);
 	J9ConstantPool *ramCPWithoutHeader = ramCP + 1;
 	UDATA ramCPCount = romClass->ramConstantPoolCount;
 	UDATA ramCPCountWithoutHeader = ramCPCount - 1;
 	
-	/* Zero the ramCP and run pre init */
+	/* Zero the ramCP and initialize constant pool */
 	if (ramCPCount != 0) {
 		memset(ramCPWithoutHeader, 0, ramCPCountWithoutHeader * sizeof(J9RAMConstantPoolItem));
-		internalRunPreInitInstructions(ramClass, _vm->mainThread);
+		internalRunPreInitInstructions(ramClass, vmThread);
 	}
 }
 
@@ -675,7 +677,7 @@ findClassLoader(J9JavaVM *javaVM, uint32_t classLoaderCategory)
 extern "C" void
 initializeImageClassLoaderObject(J9JavaVM *javaVM, J9ClassLoader *classLoader, j9object_t classLoaderObject)
 {
-	J9VMThread* vmThread = currentVMThread(javaVM);
+	J9VMThread *vmThread = currentVMThread(javaVM);
 
 	omrthread_monitor_enter(javaVM->classLoaderBlocksMutex);
 

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -443,7 +443,7 @@ JVMImage::fixupArrayClass(J9ArrayClass *clazz)
 void
 JVMImage::fixupMethodRunAddresses(J9Class *ramClass)
 {
-	J9VMThread *vmThread = currentVMThread(javaVM);
+	J9VMThread *vmThread = currentVMThread(_vm);
 	J9ROMClass *romClass = ramClass->romClass;
 
 	if (romClass->romMethodCount != 0) {
@@ -460,7 +460,7 @@ JVMImage::fixupMethodRunAddresses(J9Class *ramClass)
 void
 JVMImage::fixupConstantPool(J9Class *ramClass)
 {
-	J9VMThread *vmThread = currentVMThread(javaVM);
+	J9VMThread *vmThread = currentVMThread(_vm);
 	J9ROMClass *romClass = ramClass->romClass;
 	J9ConstantPool *ramCP = ((J9ConstantPool *) ramClass->ramConstantPool);
 	J9ConstantPool *ramCPWithoutHeader = ramCP + 1;

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -31,6 +31,7 @@
 #include "j9comp.h"
 #include "j9protos.h"
 #include "ut_j9vm.h"
+#include "VMHelpers.hpp"
 
 #define JVMIMAGE_ACCESS_FROM_OMRPORT(omrPortLib) JVMImage *jvmImage = (JVMImage *) ((JVMImagePortLibrary *) (omrPortLib)->jvmImage)
 
@@ -73,6 +74,10 @@ private:
 
 	void fixupClassLoaders(void);
 	void fixupClasses(void);
+	void fixupClass(J9Class *clazz);
+	void fixupArrayClass(J9ArrayClass *clazz);
+	void fixupMethodRunAddresses(J9Class* ramClass);
+	void fixupConstantPool(J9Class *ramClass);
 	void fixupClassPathEntries(void);
 protected:
 	void *operator new(size_t size, void *memoryPointer) { return memoryPointer; }

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -31,9 +31,6 @@
 #include "j9comp.h"
 #include "j9protos.h"
 #include "ut_j9vm.h"
-#include "VMHelpers.hpp"
-
-#define JVMIMAGE_ACCESS_FROM_OMRPORT(omrPortLib) JVMImage *jvmImage = (JVMImage *) ((JVMImagePortLibrary *) (omrPortLib)->jvmImage)
 
 class JVMImage
 {
@@ -76,7 +73,7 @@ private:
 	void fixupClasses(void);
 	void fixupClass(J9Class *clazz);
 	void fixupArrayClass(J9ArrayClass *clazz);
-	void fixupMethodRunAddresses(J9Class* ramClass);
+	void fixupMethodRunAddresses(J9Class *ramClass);
 	void fixupConstantPool(J9Class *ramClass);
 	void fixupClassPathEntries(void);
 protected:

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -377,4 +377,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 	deregisterClass,
 	deregisterCPEntry,
 	findClassLoader,
+	initializeImageClassLoaderObject,
 };

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -195,6 +195,7 @@ void freeMemorySegmentListEntry(J9MemorySegmentList *segmentList, J9MemorySegmen
 void freeMemorySegmentList(J9JavaVM *javaVM,J9MemorySegmentList *segmentList)
 {
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
+	JVMIMAGEPORT_ACCESS_FROM_JAVAVM(javaVM);
 	J9MemorySegment *currentSegment;
 
 	do {
@@ -208,7 +209,11 @@ void freeMemorySegmentList(J9JavaVM *javaVM,J9MemorySegmentList *segmentList)
 	if(segmentList->segmentMutex) omrthread_monitor_destroy(segmentList->segmentMutex);
 #endif
 
-	j9mem_free_memory(segmentList);
+	if (IS_COLD_RUN(javaVM) && javaVM->classMemorySegments == segmentList) {
+		imem_free_memory(segmentList);
+	} else {
+		j9mem_free_memory(segmentList);
+	}
 }
 
 


### PR DESCRIPTION
- Issues dealing with fixup related to constant pool
- took down shutdown sequence for now (need to find best place without
corrupting memory)
- Different fixups for arrayclass and class
- fixed classloader librariesHead and librariesTail values

Signed-off-by: akshayben <akshayben@ibm.com>