### PR TITLE
Fix Object References:

### DIFF
--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -133,6 +133,7 @@ retry:
 		omrthread_monitor_exit(vm->classTableMutex);
 
 		if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
+			/* TODO: Incorrect pathway for loading already cached class */
 			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN)) {
 				clazz = vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length);
 				clazz = vmFuncs->initializeImageClassObject(currentThread, classLoader, clazz);

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -131,8 +131,14 @@ retry:
 	if (vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length) != NULL) {
 		/* Bad, we have already defined this class - fail */
 		omrthread_monitor_exit(vm->classTableMutex);
+
 		if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
-			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, (UDATA *)*(j9object_t*)className);
+			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN)) {
+				clazz = vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length);
+				clazz = vmFuncs->initializeImageClassObject(currentThread, classLoader, clazz);
+			} else {
+				vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, (UDATA*)* (j9object_t*)className);
+			}
 		}
 		goto done;
 	}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4789,7 +4789,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *deregisterCPEntry)(struct J9JavaVM *javaVM, struct J9ClassPathEntry *cpEntry);
 	J9ClassLoader* (*findClassLoader)(struct J9JavaVM *javaVM, uint32_t classLoaderCategory);
 	void (*initializeImageClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);
-	struct J9Class* (*initializeImageClassObject)(struct J9VMThread* vmThread, struct J9ClassLoader* classLoader, struct J9Class* clazz);
+	struct J9Class* (*initializeImageClassObject)(struct J9VMThread *vmThread, struct J9ClassLoader *classLoader, struct J9Class *clazz);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4789,6 +4789,7 @@ typedef struct J9InternalVMFunctions {
 	void ( *deregisterCPEntry)(struct J9JavaVM *javaVM, struct J9ClassPathEntry *cpEntry);
 	J9ClassLoader* (*findClassLoader)(struct J9JavaVM *javaVM, uint32_t classLoaderCategory);
 	void (*initializeImageClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);
+	struct J9Class* (*initializeImageClassObject)(struct J9VMThread* vmThread, struct J9ClassLoader* classLoader, struct J9Class* clazz);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/jvmimage_api.h
+++ b/runtime/oti/jvmimage_api.h
@@ -138,8 +138,19 @@ UDATA* findEntryLocationInTable(ImageTableHeader *table, UDATA entry);
 J9ClassLoader* findClassLoader(J9JavaVM *javaVM, uint32_t classLoaderCategory);
 
 /*
-* Initializes class loader object. Mimics behaviour of internalAllocateClassLoader
+* Initializes class object. Mimics behaviour of internalCreateRAMClass
 *
+* @param javaVM[in] the java vm
+* @param classLoader the class loader loading the class
+* @param clazz the class being loader
+*
+* @return class object if object allocation passes otherwise null
+*/
+J9Class* initializeImageClassObject(J9VMThread *vmThread, J9ClassLoader *classLoader, J9Class *clazz);
+
+/*
+* Initializes class loader object. Mimics behaviour of internalAllocateClassLoader
+* 
 * @param javaVM[in] the java vm
 * @param classLoader the class loader
 * @param classLoaderObject unwrapped class loader object ref

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -697,19 +697,19 @@ initializeImageClassObject(J9VMThread *vmThread, J9ClassLoader *classLoader, J9C
 	/* Allocate class object */
 	J9Class *jlClass = J9VMCONSTANTPOOL_CLASSREF_AT(javaVM, J9VMCONSTANTPOOL_JAVALANGCLASS)->value;
 
-	if (jlClass == NULL) {
+	if (NULL == jlClass) {
 		return NULL;
 	}
 	J9Class *lockClass = J9VMJAVALANGJ9VMINTERNALSCLASSINITIALIZATIONLOCK_OR_NULL(javaVM);
 
 	j9object_t classObject = javaVM->memoryManagerFunctions->J9AllocateObject(vmThread, jlClass, J9_GC_ALLOCATE_OBJECT_TENURED | J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE | J9_GC_ALLOCATE_OBJECT_HASHED);
-	if (classObject == NULL) {
+	if (NULL == classObject) {
 		setHeapOutOfMemoryError(vmThread);
 		return NULL;
 	}
 
 	/* Allocate lock object if lock class already allocated */
-	if (lockClass != NULL) {
+	if (NULL != lockClass) {
 		j9object_t lockObject;
 		UDATA allocateFlags = J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE;
 
@@ -717,7 +717,7 @@ initializeImageClassObject(J9VMThread *vmThread, J9ClassLoader *classLoader, J9C
 		lockObject = javaVM->memoryManagerFunctions->J9AllocateObject(vmThread, lockClass, allocateFlags);
 		classObject = POP_OBJECT_IN_SPECIAL_FRAME(vmThread);
 
-		if (lockObject == NULL) {
+		if (NULL == lockObject) {
 			setHeapOutOfMemoryError(vmThread);
 			return NULL;
 		}

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -689,6 +689,49 @@ initializeImageClassLoaderObject(J9JavaVM *javaVM, J9ClassLoader *classLoader, j
 	omrthread_monitor_exit(javaVM->classLoaderBlocksMutex);
 }
 
+extern "C" J9Class * 
+initializeImageClassObject(J9VMThread *vmThread, J9ClassLoader *classLoader, J9Class *clazz)
+{
+	J9JavaVM *javaVM = vmThread->javaVM;
+
+	/* Allocate class object */
+	J9Class *jlClass = J9VMCONSTANTPOOL_CLASSREF_AT(javaVM, J9VMCONSTANTPOOL_JAVALANGCLASS)->value;
+
+	if (jlClass == NULL) {
+		return NULL;
+	}
+	J9Class *lockClass = J9VMJAVALANGJ9VMINTERNALSCLASSINITIALIZATIONLOCK_OR_NULL(javaVM);
+
+	j9object_t classObject = javaVM->memoryManagerFunctions->J9AllocateObject(vmThread, jlClass, J9_GC_ALLOCATE_OBJECT_TENURED | J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE | J9_GC_ALLOCATE_OBJECT_HASHED);
+	if (classObject == NULL) {
+		setHeapOutOfMemoryError(vmThread);
+		return NULL;
+	}
+
+	/* Allocate lock object if lock class already allocated */
+	if (lockClass != NULL) {
+		j9object_t lockObject;
+		UDATA allocateFlags = J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE;
+
+		PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, (j9object_t)classObject);
+		lockObject = javaVM->memoryManagerFunctions->J9AllocateObject(vmThread, lockClass, allocateFlags);
+		classObject = POP_OBJECT_IN_SPECIAL_FRAME(vmThread);
+
+		if (lockObject == NULL) {
+			setHeapOutOfMemoryError(vmThread);
+			return NULL;
+		}
+		J9VMJAVALANGJ9VMINTERNALSCLASSINITIALIZATIONLOCK_SET_THECLASS(vmThread, lockObject, classObject);
+		J9VMJAVALANGCLASS_SET_INITIALIZATIONLOCK(vmThread, classObject, lockObject);
+	}
+
+	J9VMJAVALANGCLASS_SET_CLASSLOADER(vmThread, classObject, classLoader->classLoaderObject);
+	J9VMJAVALANGCLASS_SET_VMREF(vmThread, classObject, clazz);
+	J9STATIC_OBJECT_STORE(vmThread, clazz, (j9object_t*)&clazz->classObject, (j9object_t)classObject);
+
+	return clazz;
+}
+
 extern "C" void
 shutdownJVMImage(J9JavaVM *javaVM)
 {

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -31,6 +31,7 @@
 #include "j9comp.h"
 #include "j9protos.h"
 #include "ut_j9vm.h"
+#include "objhelp.h"
 
 class JVMImage
 {

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -954,7 +954,7 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 	foundClass = hashClassTableAt(classLoader, className, classNameLength);
 	if (NULL != foundClass) {
 		if (IS_WARM_RUN(vmThread->javaVM)
-			&& classLoader != vmThread->javaVM->systemClassLoader
+			&& J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_CLASS_OBJECT_ASSIGNED)
 			&& foundClass->classObject == NULL) {
 			foundClass = initializeImageClassObject(vmThread, classLoader, foundClass);
 		}

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -954,7 +954,7 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 	foundClass = hashClassTableAt(classLoader, className, classNameLength);
 	if (NULL != foundClass) {
 		if (IS_WARM_RUN(vmThread->javaVM)
-			&& J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_CLASS_OBJECT_ASSIGNED)
+			&& J9_ARE_ALL_BITS_SET(vmThread->javaVM->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_CLASS_OBJECT_ASSIGNED)
 			&& foundClass->classObject == NULL) {
 			foundClass = initializeImageClassObject(vmThread, classLoader, foundClass);
 		}

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -953,6 +953,12 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 
 	foundClass = hashClassTableAt(classLoader, className, classNameLength);
 	if (NULL != foundClass) {
+		if (IS_WARM_RUN(vmThread->javaVM)
+			&& classLoader != vmThread->javaVM->systemClassLoader
+			&& foundClass->classObject == NULL) {
+			foundClass = initializeImageClassObject(vmThread, classLoader, foundClass);
+		}
+		
 		if (!fastMode) {
 			omrthread_monitor_exit(vmThread->javaVM->classTableMutex);
 		}

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -378,4 +378,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 	deregisterCPEntry,
 	findClassLoader,
 	initializeImageClassLoaderObject,
+	initializeImageClassObject,
 };


### PR DESCRIPTION
- fixup object refs for classes found inside hashtable
- two pathways related to jcldefine and resolvesupport
- created function initializeImageClassObject

Signed-off-by: akshayben <akshayben@ibm.com>