### PR TITLE
JIT Support

### DIFF
--- a/runtime/compiler/build/toolcfg/gnu/common.mk
+++ b/runtime/compiler/build/toolcfg/gnu/common.mk
@@ -103,7 +103,8 @@ CX_FLAGS+=\
     -fasynchronous-unwind-tables \
     -Wreturn-type \
     -fno-strict-aliasing \
-    -fstack-protector
+    -fstack-protector \
+    -g
 
 ifneq ($(JITSERVER_SUPPORT),)
     CXX_FLAGS+=\
@@ -434,7 +435,9 @@ endif # HOST_ARCH == aarch64
 SOLINK_CMD?=$(CXX)
 
 SOLINK_FLAGS+=
-SOLINK_FLAGS_PROD+=-Wl,-S
+#SOLINK_FLAGS_PROD+=-Wl,-S
+SOLINK_FLAGS_PROD+=
+
 
 SOLINK_LIBPATH+=$(PRODUCT_LIBPATH)
 SOLINK_SLINK+=$(PRODUCT_SLINK) j9thr$(J9_VERSION) j9hookable$(J9_VERSION)

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -994,6 +994,9 @@ public:
    bool getSuspendThreadDueToLowPhysicalMemory() const { return _suspendThreadDueToLowPhysicalMemory; }
    void setSuspendThreadDueToLowPhysicalMemory(bool b) { _suspendThreadDueToLowPhysicalMemory = b; }
 
+   bool shouldRetryLoad(void *j9method);
+   bool retryLoadIfPossible(void *j9method, Compilation *comp);
+
 #if defined(JITSERVER_SUPPORT)
    ClientSessionHT *getClientSessionHT() const { return _clientSessionHT; }
    void setClientSessionHT(ClientSessionHT *ht) { _clientSessionHT = ht; }
@@ -1169,6 +1172,11 @@ private:
    int32_t                _numSeriousFailures; // count failures where method needs to continue interpreted
 
    TR::Monitor           *_gpuInitMonitor;
+
+   typedef TR::typed_allocator<std::pair<void* const, uint32_t>, TR_TypedPersistentAllocatorBase&> LoadRetryAllocator;
+   typedef std::less<void*> LoadRetryComparator;
+   typedef std::map<void*, uint32_t, LoadRetryComparator, LoadRetryAllocator> LoadRetryMap;
+   LoadRetryMap           _loadRetryMap;
 
    enum // flags
       {

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9035,6 +9035,9 @@ TR::CompilationInfoPerThreadBase::compile(
             metaData = (J9JITExceptionTable *)persistentMemory(_jitConfig)->getPCFromMap(static_cast<void *>(method));
             if (metaData)
                {
+               if (TR::Options::_verboseImage > 0)
+                  printf("Found start pc %p!\n", (void *)metaData->startPC);
+
                struct ReloBuffer *reloBuffer = (struct ReloBuffer *)metaData->reloBuffer;
 
                bool success = false;
@@ -9045,11 +9048,19 @@ TR::CompilationInfoPerThreadBase::compile(
                catch (...)
                   {
                   // Catch any SVM Asserts
+                  if (TR::Options::_verboseImage > 0)
+                     printf("EXCEPTION THROWN: Failed to validate %p!\n", metaData->startPC);
                   }
                if (!success)
+                  {
+                  if (TR::Options::_verboseImage > 0)
+                     printf("Failed to validate %p!\n", metaData->startPC);
                   compiler->failCompilation<J9::RetryLoadAfterSomeTime>("Failed validation records");
+                  }
 
                foundMethodInMap = true;
+               if (TR::Options::_verboseImage > 0)
+                  printf("Validation succeeded for %p!\n", metaData->startPC);
                }
             }
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1068,7 +1068,8 @@ TR::CompilationInfo::CompilationInfo(J9JITConfig *jitConfig) :
    _samplingThreadWaitTimeInDeepIdleToNotifyVM(-1),
    _numDiagnosticThreads(0),
    _numCompThreads(0),
-   _arrayOfCompilationInfoPerThread(NULL)
+   _arrayOfCompilationInfoPerThread(NULL),
+   _loadRetryMap((LoadRetryComparator()), TR_TypedPersistentAllocatorBase())
    {
    // The object is zero-initialized before this method is called
    //
@@ -2134,6 +2135,8 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
    TR::IlGeneratorMethodDetails & details = entry->getMethodDetails();
    J9Method *method = details.getMethod();
 
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+
    // when the compilation fails we might retry
    //
    if (entry->_compErrCode != compilationOK &&
@@ -2145,6 +2148,14 @@ bool TR::CompilationInfo::shouldRetryCompilation(TR_MethodToBeCompiled *entry, T
          TR_PersistentJittedBodyInfo *bodyInfo;
          switch (entry->_compErrCode)
             {
+            case compilationRetryAfterSomeTime:
+               {
+               if (compInfo->retryLoadIfPossible((void *)method, comp))
+                  {
+                  tryCompilingAgain = true;
+                  }
+               }
+               break;
             case compilationAotValidateFieldFailure:
             case compilationAotStaticFieldReloFailure:
             case compilationAotClassReloFailure:
@@ -4260,7 +4271,7 @@ TR::CompilationInfoPerThread::processEntry(TR_MethodToBeCompiled &entry, J9::J9S
    // Copy this because it is needed later and entry may be recycled
    bool tryCompilingAgain = entry._tryCompilingAgain;
 
-   if (entry._tryCompilingAgain)
+   if (entry._tryCompilingAgain && !compInfo->shouldRetryLoad((void *)entry.getMethodDetails().getMethod()))
       {
       // We got interrupted during the compile, and want to requeue this compilation request
       //
@@ -10362,7 +10373,12 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
       // Tell the VM that a non-compiled method failed translation
       //
       if (vmThread && entry && !entry->isOutOfProcessCompReq())
-         jitMethodFailedTranslation(vmThread, method);
+         {
+         if (!IS_RAM_CACHE_ON(jitConfig->javaVM) || !compInfo->shouldRetryLoad((void *)method))
+            {
+            jitMethodFailedTranslation(vmThread, method);
+            }
+         }
 #if defined(JITSERVER_SUPPORT)
       if (entry && isJITServerMode) // failure at the JITServer
          {
@@ -11075,6 +11091,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTNoSupportForAOTFailure &e)
       {
       _methodBeingCompiled->_compErrCode = compilationAOTNoSupportForAOTFailure;
+      }
+   catch (const J9::RetryLoadAfterSomeTime &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationRetryAfterSomeTime;
       }
    catch (const J9::ClassChainPersistenceFailure &e)
       {
@@ -12875,6 +12895,80 @@ TR::CompilationInfo::canRelocateMethod(TR::Compilation *comp)
          }
       }
    return canRelocateMethod;
+   }
+
+/*
+ * Assumes the Compilation Monitor has been acquired
+ */
+bool TR::CompilationInfo::shouldRetryLoad(void *j9method)
+   {
+   LoadRetryMap::iterator it = _loadRetryMap.find(j9method);
+   return (it != _loadRetryMap.end());
+   }
+
+/*
+ * Assumes the Compilation Monitor has been acquired
+ */
+bool TR::CompilationInfo::retryLoadIfPossible(void *j9method, TR::Compilation *comp)
+   {
+   bool retryLoad = false;
+   int32_t loadRetryInvocationCount = J9::Options::_retryLoadInitialInvocationCount;
+
+   if (loadRetryInvocationCount < 1)
+      return false;
+
+   J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(j9method);
+   bool loopy = J9ROMMETHOD_HAS_BACKWARDS_BRANCHES(romMethod);
+   int32_t initialInvocationCount;
+   if (loopy)
+      {
+      initialInvocationCount = comp->getOptions()->getInitialBCount();
+      }
+   else
+      {
+      initialInvocationCount = comp->getOptions()->getInitialCount();
+      }
+
+   LoadRetryMap::iterator it = _loadRetryMap.find(j9method);
+   if (it == _loadRetryMap.end())
+      {
+      _loadRetryMap.insert(std::make_pair(j9method, loadRetryInvocationCount));
+      retryLoad = true;
+      }
+   else
+      {
+      loadRetryInvocationCount = it->second * 2;
+      if (loadRetryInvocationCount <= (initialInvocationCount/2))
+         {
+         it->second = loadRetryInvocationCount;
+         retryLoad = true;
+         }
+      else
+         {
+         _loadRetryMap.erase(it);
+         }
+      }
+
+   if (retryLoad)
+      {
+      int32_t methodVMExtra = TR::CompilationInfo::getJ9MethodVMExtra(static_cast<J9Method *>(j9method));
+      if (methodVMExtra == 1 || methodVMExtra == J9_JIT_QUEUED_FOR_COMPILATION)
+         {
+         if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Will retry Load of %p; setting invocationCount to %d",
+                                          j9method, loadRetryInvocationCount);
+            }
+
+         TR::CompilationInfo::setInvocationCount(static_cast<J9Method *>(j9method), loadRetryInvocationCount);
+         }
+      else
+         {
+         retryLoad = false;
+         }
+      }
+
+   return retryLoad;
    }
 
 #if defined(JITSERVER_SUPPORT)

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10480,7 +10480,11 @@ TR::CompilationInfoPerThreadBase::methodCanBeCompiled(TR_Memory *trMemory, TR_Fr
 
    static char *dontCompileNatives = feGetEnv("TR_DontCompile");
 
-   if (dontCompileNatives && (method->isNewInstanceImplThunk() || method->isJNINative()))
+   bool noNativeCompilation = (dontCompileNatives != NULL);
+   if (IS_RAM_CACHE_ON(_compInfo.getJITConfig()->javaVM))
+      noNativeCompilation = true;
+
+   if (noNativeCompilation && (method->isNewInstanceImplThunk() || method->isJNINative()))
       {
       printf("don't compile because JNI or thunk\n");
       return false;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9031,11 +9031,24 @@ TR::CompilationInfoPerThreadBase::compile(
 
          if (IS_RAM_CACHE_ON(_jitConfig->javaVM) && _methodBeingCompiled->_oldStartPC == NULL)
             {
-            TR_TranslationArtifactManager *artifactManager = TR_TranslationArtifactManager::getGlobalArtifactManager();
             TR_TranslationArtifactManager::CriticalSection getPCFromMap;
             metaData = (J9JITExceptionTable *)persistentMemory(_jitConfig)->getPCFromMap(static_cast<void *>(method));
             if (metaData)
                {
+               struct ReloBuffer *reloBuffer = (struct ReloBuffer *)metaData->reloBuffer;
+
+               bool success = false;
+               try
+                  {
+                  success = compiler->getSymbolValidationManager()->validateRecordsInBuffer((void *)reloBuffer->buffer, reloBuffer->size);
+                  }
+               catch (...)
+                  {
+                  // Catch any SVM Asserts
+                  }
+               if (!success)
+                  compiler->failCompilation<J9::RetryLoadAfterSomeTime>("Failed validation records");
+
                foundMethodInMap = true;
                }
             }

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -127,6 +127,12 @@ struct CompileParameters
    TR::CompileIlGenRequest  _ilGenRequest;
    };
 
+struct ReloBuffer
+   {
+   uintptrj_t size;
+   char buffer[1];
+   };
+
 #if defined(TR_HOST_S390)
 struct timeval;
 #endif

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -320,7 +320,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                if (aotrtInitialized)
                   jitConfig->runtimeFlags |= J9JIT_AOT_ATTACHED;
 
-               if (jitConfig->runtimeFlags & J9JIT_JIT_ATTACHED)
+               if (!IS_RAM_CACHE_ON(vm) && jitConfig->runtimeFlags & J9JIT_JIT_ATTACHED)
                   goto _abort;
                if (onLoadInternal(vm, jitConfig, xjitCommandLineOptions, xaotCommandLineOptions, initialFlags, reserved, isJIT?0:1))
                   goto _abort;

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -261,6 +261,8 @@ int32_t J9::Options::_jProfilingEnablementSampleThreshold = 10000;
 
 bool J9::Options::_aggressiveLockReservation = false;
 
+int32_t J9::Options::_retryLoadInitialInvocationCount = -1;
+
 //************************************************************************
 //
 // Options handling - the following code implements the VM-specific
@@ -916,6 +918,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_relaxedCompilationLimitsSampleThreshold, 0, " %d", NOT_IN_SUBSET },
    {"resetCountThreshold=", "R<nnn>\tThe number of global samples which if exceed during a method's sampling interval will cause the method's sampling counter to be incremented by the number of samples in a sampling interval",
         TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_resetCountThreshold, 0, " %d", NOT_IN_SUBSET},
+   {"retryAOTLoadInitialInvocationCount=", "M<nnn>\tInvocation count for an AOT load that will be retried",
+        TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_retryLoadInitialInvocationCount, 0, "F%d", NOT_IN_SUBSET},
    {"rtlog=",             "L<filename>\twrite verbose run-time output to filename",
         TR::Options::setStringForPrivateBase,  offsetof(TR_JitPrivateConfig,rtLogFileName), 0, "P%s"},
    {"rtResolve",          "D\ttreat all data references as unresolved", SET_JITCONFIG_RUNTIME_FLAG(J9JIT_RUNTIME_RESOLVE) },

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -116,6 +116,8 @@ int32_t J9::Options::_numClassLoadPhaseQuiesceIntervals = 1;
 int32_t J9::Options::_userClassLoadingPhaseThreshold = 5;
 bool J9::Options::_userClassLoadingPhase = false;
 
+int32_t J9::Options::_verboseImage = 0;
+
 int32_t J9::Options::_bigAppSampleThresholdAdjust = 3; //amount to shift the hot and scorching threshold
 int32_t J9::Options::_availableCPUPercentage = 100;
 int32_t J9::Options::_cpuCompTimeExpensiveThreshold = 4000;
@@ -993,6 +995,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setVerboseBitsInJitPrivateConfig, offsetof(J9JITConfig, privateConfig), 5, "F=1"},
    {"verbose=",           "L{regex}\tlist of verbose output to write to vlog or stdout",
         TR::Options::setVerboseBitsInJitPrivateConfig, offsetof(J9JITConfig, privateConfig), 0, "F"},
+   {"verboseImage=",          "R<nnn>\tImage verbose level",
+        TR::Options::setStaticNumeric, (intptrj_t)&TR::Options::_verboseImage, 0, " %d", NOT_IN_SUBSET},
    {"version",            "L\tdisplay the jit build version",
         TR::Options::versionOption, 0, 0, "F"},
    {"veryHotSampleThreshold=",          "R<nnn>\tThe maximum number of global samples taken during a sample interval for which the method will be recompiled at hot with normal priority",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -312,6 +312,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static bool _aggressiveLockReservation;
 
+   static int32_t _retryLoadInitialInvocationCount;
+
    static void  printPID();
 
 

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -160,6 +160,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _userClassLoadingPhaseThreshold;
    static bool _userClassLoadingPhase;
 
+   static int32_t _verboseImage;
+
    static int32_t _cpuCompTimeExpensiveThreshold;
    int32_t getCpuCompTimeExpensiveThreshold() { return _cpuCompTimeExpensiveThreshold; }
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1043,6 +1043,7 @@ onLoadInternal(
       I_32 xnojit)
    {
    PORT_ACCESS_FROM_JAVAVM(javaVM);
+   JVMIMAGEPORT_ACCESS_FROM_JAVAVM(javaVM);
 
    jitConfig->javaVM = javaVM;
    jitConfig->jitLevelName = TR_BUILD_NAME;
@@ -1337,6 +1338,33 @@ onLoadInternal(
    memset(aotStats, 0, sizeof(TR_AOTStats));
    ((TR_JitPrivateConfig*)jitConfig->privateConfig)->aotStats = aotStats;
 
+   // Do not allow code caches smaller than 128KB
+   if (jitConfig->codeCacheKB < 128)
+      jitConfig->codeCacheKB = 128;
+   if (!fe->isAOT_DEPRECATED_DO_NOT_USE())
+      {
+      if (jitConfig->codeCacheKB > 32768)
+         jitConfig->codeCacheKB = 32768;
+      }
+
+   if (jitConfig->codeCacheKB > jitConfig->codeCacheTotalKB)
+      {
+      /* Handle case where user has set codeCacheTotalKB smaller than codeCacheKB (e.g. -Xjit:codeTotal=256) by setting codeCacheKB = codeCacheTotalKB */
+      jitConfig->codeCacheKB = jitConfig->codeCacheTotalKB;
+      }
+
+   if (jitConfig->dataCacheKB > jitConfig->dataCacheTotalKB)
+      {
+      /* Handle case where user has set dataCacheTotalKB smaller than dataCacheKB (e.g. -Xjit:dataTotal=256) by setting dataCacheKB = dataCacheTotalKB */
+      jitConfig->dataCacheKB = jitConfig->dataCacheTotalKB;
+      }
+
+   I_32 maxNumberOfCodeCaches = jitConfig->codeCacheTotalKB / jitConfig->codeCacheKB;
+   if (fe->isAOT_DEPRECATED_DO_NOT_USE())
+      maxNumberOfCodeCaches = 1;
+
+   if (!TR_TranslationArtifactManager::initializeGlobalArtifactManager(jitConfig->translationArtifacts, jitConfig->javaVM))
+      return -1;
 
    if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
       {
@@ -1356,36 +1384,8 @@ onLoadInternal(
 
       TR::CodeCacheConfig &codeCacheConfig = codeCacheManager->codeCacheConfig();
 
-      // Do not allow code caches smaller than 128KB
-      if (jitConfig->codeCacheKB < 128)
-         jitConfig->codeCacheKB = 128;
-      if (!fe->isAOT_DEPRECATED_DO_NOT_USE())
-         {
-         if (jitConfig->codeCacheKB > 32768)
-            jitConfig->codeCacheKB = 32768;
-         }
-
-      if (jitConfig->codeCacheKB > jitConfig->codeCacheTotalKB)
-         {
-         /* Handle case where user has set codeCacheTotalKB smaller than codeCacheKB (e.g. -Xjit:codeTotal=256) by setting codeCacheKB = codeCacheTotalKB */
-         jitConfig->codeCacheKB = jitConfig->codeCacheTotalKB;
-         }
-
-      if (jitConfig->dataCacheKB > jitConfig->dataCacheTotalKB)
-         {
-         /* Handle case where user has set dataCacheTotalKB smaller than dataCacheKB (e.g. -Xjit:dataTotal=256) by setting dataCacheKB = dataCacheTotalKB */
-         jitConfig->dataCacheKB = jitConfig->dataCacheTotalKB;
-         }
-
-      I_32 maxNumberOfCodeCaches = jitConfig->codeCacheTotalKB / jitConfig->codeCacheKB;
-      if (fe->isAOT_DEPRECATED_DO_NOT_USE())
-         maxNumberOfCodeCaches = 1;
-
       // setupCodeCacheParameters must stay before  TR::CodeCacheManager::initialize() because it needs trampolineCodeSize
       setupCodeCacheParameters(&codeCacheConfig._trampolineCodeSize, &codeCacheConfig._mccCallbacks, &codeCacheConfig._numOfRuntimeHelpers, &codeCacheConfig._CCPreLoadedCodeSize);
-
-      if (!TR_TranslationArtifactManager::initializeGlobalArtifactManager(jitConfig->translationArtifacts, jitConfig->javaVM))
-         return -1;
 
       codeCacheConfig._allowedToGrowCache = (javaVM->jitConfig->runtimeFlags & J9JIT_GROW_CACHES) != 0;
       codeCacheConfig._lowCodeCacheThreshold = TR::Options::_lowCodeCacheThreshold;
@@ -1777,6 +1777,26 @@ onLoadInternal(
       {
       TR::CodeCacheManager::setInstance((TR::CodeCacheManager*)(((TR_CacheForImage *)jitConfig->cacheForImage)->codeCacheManager));
       TR_DataCacheManager::setManager((TR_DataCacheManager *)(((TR_CacheForImage *)jitConfig->cacheForImage)->dataCacheManager));
+
+      J9ThreadMonitor **cacheListMutex = (J9ThreadMonitor **)TR::CodeCacheManager::instance()->cacheListMutex()->getVMMonitorAddr();
+      J9ThreadMonitor **ccRepoMutex = (J9ThreadMonitor **)TR::CodeCacheManager::instance()->getCodeCacheRepositoryMonitor()->getVMMonitorAddr();
+      J9ThreadMonitor **dataCacheMutex = (J9ThreadMonitor **)TR_DataCacheManager::getManager()->getMonitor()->getVMMonitorAddr();
+
+      if (omrthread_monitor_init_with_name(cacheListMutex, 0, "JIT-CodeCacheListMutex"))
+         return -1;
+      if (omrthread_monitor_init_with_name(ccRepoMutex, 0, "CodeCacheRepositoryMonitor"))
+         return -1;
+      if (omrthread_monitor_init_with_name(dataCacheMutex, 0, "JIT-DataCacheManagerMutex"))
+         return -1;
+
+      /*
+       * Must be done before registering code caches
+       */
+      TR::CodeCacheManager::setJitConfig(jitConfig);
+      TR::CodeCacheManager::setJavaVM(javaVM);
+
+      if (!TR::CodeCacheManager::instance()->registerCodeCaches())
+         return -1;
       }
 
    return 0;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1797,6 +1797,24 @@ onLoadInternal(
 
       if (!TR::CodeCacheManager::instance()->registerCodeCaches())
          return -1;
+
+
+      /*
+       * Critical Section
+       */
+         {
+         TR_TranslationArtifactManager *artifactManager = TR_TranslationArtifactManager::getGlobalArtifactManager();
+         TR_TranslationArtifactManager::CriticalSection getPCFromMap;
+
+         TR_PersistentMemory::MethodToPCMap &map = persistentMemory->_methodToPCMap;
+         for (auto it = map.begin(); it != map.end(); it++)
+            {
+            J9JITExceptionTable *metadata = (J9JITExceptionTable *)it->second;
+            if (!artifactManager->containsArtifact(metadata))
+               if (!artifactManager->insertArtifact(metadata))
+                  return -1;
+            }
+         }
       }
 
    return 0;

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1723,6 +1723,24 @@ onLoadInternal(
          return -1;
       persistentMemory->getPersistentInfo()->setInvokeExactJ2IThunkTable(ieThunkTable);
       }
+
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
+      {
+      jitConfig->cacheForImage = persistentMemory->allocatePersistentMemory(sizeof(TR_CacheForImage));
+      memset(jitConfig->cacheForImage, 0, sizeof(TR_CacheForImage));
+      ((TR_CacheForImage *)jitConfig->cacheForImage)->persistentMemory = (void *)persistentMemory;
+      ((TR_CacheForImage *)jitConfig->cacheForImage)->monitorTable = (void *)TR::MonitorTable::get();
+      ((TR_CacheForImage *)jitConfig->cacheForImage)->compilerEnv = (void *)TR::Compiler;
+      ((TR_CacheForImage *)jitConfig->cacheForImage)->codeCacheManager = (void *)TR::CodeCacheManager::instance();
+      ((TR_CacheForImage *)jitConfig->cacheForImage)->dataCacheManager = (void *)TR_DataCacheManager::getManager();
+      ((TR_CacheForImage *)jitConfig->cacheForImage)->globalFrontend = (void *)feWithoutThread;
+      }
+   else
+      {
+      TR::CodeCacheManager::setInstance((TR::CodeCacheManager*)(((TR_CacheForImage *)jitConfig->cacheForImage)->codeCacheManager));
+      TR_DataCacheManager::setManager((TR_DataCacheManager *)(((TR_CacheForImage *)jitConfig->cacheForImage)->dataCacheManager));
+      }
+
    return 0;
    }
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -218,6 +218,7 @@ char *compilationErrorNames[]={
    "compilationStreamVersionIncompatible", // 56
    "compilationStreamInterrupted", // 57
 #endif /* defined(JITSERVER_SUPPORT) */
+   "compilationRetryAfterSomeTime", // 58
    "compilationMaxError"
 };
 

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -116,6 +116,9 @@
 #include "runtime/JITServerIProfiler.hpp"
 #endif
 
+#include "jvmimage.h"
+#include "jvmimageport.h"
+
 extern "C" int32_t encodeCount(int32_t count);
 
 #if defined(TR_HOST_POWER)
@@ -1046,15 +1049,25 @@ onLoadInternal(
 
    TR::CodeCache *firstCodeCache;
 
-   /* Allocate the code and data cache lists */
-   if (!(jitConfig->codeCacheList))
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
       {
-      if ((jitConfig->codeCacheList = javaVM->internalVMFunctions->allocateMemorySegmentList(javaVM, 3, J9MEM_CATEGORY_JIT)) == NULL)
-         return -1;
+      /* Allocate the code and data cache lists */
+      if (!(jitConfig->codeCacheList))
+         {
+         if ((jitConfig->codeCacheList = javaVM->internalVMFunctions->allocateMemorySegmentList(javaVM, 3, J9MEM_CATEGORY_JIT)) == NULL)
+            return -1;
+         }
+      if (!(jitConfig->dataCacheList))
+         {
+         if ((jitConfig->dataCacheList = javaVM->internalVMFunctions->allocateMemorySegmentList(javaVM, 3, J9MEM_CATEGORY_JIT)) == NULL)
+            return -1;
+         }
       }
-   if (!(jitConfig->dataCacheList))
+   else
       {
-      if ((jitConfig->dataCacheList = javaVM->internalVMFunctions->allocateMemorySegmentList(javaVM, 3, J9MEM_CATEGORY_JIT)) == NULL)
+      if (omrthread_monitor_init_with_name(&(jitConfig->codeCacheList->segmentMutex), 0, "VM mem segment list"))
+         return -1;
+      if (omrthread_monitor_init_with_name(&(jitConfig->dataCacheList->segmentMutex), 0, "VM mem segment list"))
          return -1;
       }
 
@@ -1124,22 +1137,31 @@ onLoadInternal(
    TR_VerboseLog::initialize(jitConfig);
    initializePersistentMemory(jitConfig);
 
-
    TR_PersistentMemory * persistentMemory = (TR_PersistentMemory *)jitConfig->scratchSegment;
-   if (persistentMemory == NULL)
-      return -1;
 
-   // JITServer: persistentCHTable used to be inited here, but we have to move it after JITServer commandline opts
-   // setting it to null here to catch anything that assumes it's set between here and the new init code.
-   persistentMemory->getPersistentInfo()->setPersistentCHTable(NULL);
-
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
+      {
+      // JITServer: persistentCHTable used to be inited here, but we have to move it after JITServer commandline opts
+      // setting it to null here to catch anything that assumes it's set between here and the new init code.
+      persistentMemory->getPersistentInfo()->setPersistentCHTable(NULL);
+      }
+   
    if (!TR::CompilationInfo::createCompilationInfo(jitConfig))
       return -1;
 
    if (!TR_J9VMBase::createGlobalFrontEnd(jitConfig, TR::CompilationInfo::get()))
       return -1;
 
-   TR_J9VMBase * feWithoutThread(TR_J9VMBase::get(jitConfig, NULL));
+   TR_J9VMBase * feWithoutThread;
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
+      {
+      feWithoutThread = TR_J9VMBase::get(jitConfig, NULL);
+      }
+   else
+      {
+      feWithoutThread = (TR_J9VMBase *)(((TR_CacheForImage *)jitConfig->cacheForImage)->globalFrontend);
+      }
+
    if (!feWithoutThread)
       return -1;
 
@@ -1288,13 +1310,16 @@ onLoadInternal(
       numCodeCachesToCreateAtStartup = 4;
 #endif
 
-   if (!persistentMemory->getPersistentInfo()->getRuntimeAssumptionTable()->init())
-      return -1;
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
+      {
+      if (!persistentMemory->getPersistentInfo()->getRuntimeAssumptionTable()->init())
+         return -1;
 
-   TR_PersistentClassLoaderTable *loaderTable = new (PERSISTENT_NEW) TR_PersistentClassLoaderTable(persistentMemory);
-   if (loaderTable == NULL)
-      return -1;
-   persistentMemory->getPersistentInfo()->setPersistentClassLoaderTable(loaderTable);
+      TR_PersistentClassLoaderTable *loaderTable = new (PERSISTENT_NEW) TR_PersistentClassLoaderTable(persistentMemory);
+      if (loaderTable == NULL)
+         return -1;
+      persistentMemory->getPersistentInfo()->setPersistentClassLoaderTable(loaderTable);
+      }
 
    jitConfig->iprofilerBufferSize = TR::Options::_iprofilerBufferSize;   //1024;
 
@@ -1312,90 +1337,112 @@ onLoadInternal(
    memset(aotStats, 0, sizeof(TR_AOTStats));
    ((TR_JitPrivateConfig*)jitConfig->privateConfig)->aotStats = aotStats;
 
-   TR::CodeCacheManager *codeCacheManager = (TR::CodeCacheManager *) j9mem_allocate_memory(sizeof(TR::CodeCacheManager), J9MEM_CATEGORY_JIT);
-   if (codeCacheManager == NULL)
-      return -1;
-   memset(codeCacheManager, 0, sizeof(TR::CodeCacheManager));
 
-   // must initialize manager using the global (not thread specific) fe because current thread isn't guaranteed to live longer than the manager
-   new (codeCacheManager) TR::CodeCacheManager(feWithoutThread, TR::Compiler->rawAllocator);
-
-   TR::CodeCacheConfig &codeCacheConfig = codeCacheManager->codeCacheConfig();
-
-   // Do not allow code caches smaller than 128KB
-   if (jitConfig->codeCacheKB < 128)
-      jitConfig->codeCacheKB = 128;
-   if (!fe->isAOT_DEPRECATED_DO_NOT_USE())
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
       {
-      if (jitConfig->codeCacheKB > 32768)
-         jitConfig->codeCacheKB = 32768;
-      }
+      TR::CodeCacheManager *codeCacheManager;
 
-   if (jitConfig->codeCacheKB > jitConfig->codeCacheTotalKB)
-      {
-      /* Handle case where user has set codeCacheTotalKB smaller than codeCacheKB (e.g. -Xjit:codeTotal=256) by setting codeCacheKB = codeCacheTotalKB */
-      jitConfig->codeCacheKB = jitConfig->codeCacheTotalKB;
-      }
+      if (IS_RAM_CACHE_ON(javaVM))
+         codeCacheManager = (TR::CodeCacheManager *) imem_allocate_memory(sizeof(TR::CodeCacheManager), J9MEM_CATEGORY_JIT);
+      else
+         codeCacheManager = (TR::CodeCacheManager *) j9mem_allocate_memory(sizeof(TR::CodeCacheManager), J9MEM_CATEGORY_JIT);
 
-   if (jitConfig->dataCacheKB > jitConfig->dataCacheTotalKB)
-      {
-      /* Handle case where user has set dataCacheTotalKB smaller than dataCacheKB (e.g. -Xjit:dataTotal=256) by setting dataCacheKB = dataCacheTotalKB */
-      jitConfig->dataCacheKB = jitConfig->dataCacheTotalKB;
-      }
+      if (codeCacheManager == NULL)
+         return -1;
+      memset(codeCacheManager, 0, sizeof(TR::CodeCacheManager));
 
-   I_32 maxNumberOfCodeCaches = jitConfig->codeCacheTotalKB / jitConfig->codeCacheKB;
-   if (fe->isAOT_DEPRECATED_DO_NOT_USE())
-      maxNumberOfCodeCaches = 1;
+      // must initialize manager using the global (not thread specific) fe because current thread isn't guaranteed to live longer than the manager
+      new (codeCacheManager) TR::CodeCacheManager(feWithoutThread, TR::Compiler->rawAllocator);
 
-   // setupCodeCacheParameters must stay before  TR::CodeCacheManager::initialize() because it needs trampolineCodeSize
-   setupCodeCacheParameters(&codeCacheConfig._trampolineCodeSize, &codeCacheConfig._mccCallbacks, &codeCacheConfig._numOfRuntimeHelpers, &codeCacheConfig._CCPreLoadedCodeSize);
+      TR::CodeCacheConfig &codeCacheConfig = codeCacheManager->codeCacheConfig();
 
-   if (!TR_TranslationArtifactManager::initializeGlobalArtifactManager(jitConfig->translationArtifacts, jitConfig->javaVM))
-      return -1;
+      // Do not allow code caches smaller than 128KB
+      if (jitConfig->codeCacheKB < 128)
+         jitConfig->codeCacheKB = 128;
+      if (!fe->isAOT_DEPRECATED_DO_NOT_USE())
+         {
+         if (jitConfig->codeCacheKB > 32768)
+            jitConfig->codeCacheKB = 32768;
+         }
 
-   codeCacheConfig._allowedToGrowCache = (javaVM->jitConfig->runtimeFlags & J9JIT_GROW_CACHES) != 0;
-   codeCacheConfig._lowCodeCacheThreshold = TR::Options::_lowCodeCacheThreshold;
-   codeCacheConfig._verboseCodeCache = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCodeCache);
-   codeCacheConfig._verbosePerformance = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance);
-   codeCacheConfig._verboseReclamation = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCodeCacheReclamation);
-   codeCacheConfig._doSanityChecks = TR::Options::getCmdLineOptions()->getOption(TR_CodeCacheSanityCheck);
-   codeCacheConfig._codeCacheTotalKB = jitConfig->codeCacheTotalKB;
-   codeCacheConfig._codeCacheKB = jitConfig->codeCacheKB;
-   codeCacheConfig._codeCachePadKB = jitConfig->codeCachePadKB;
-   codeCacheConfig._codeCacheAlignment = jitConfig->codeCacheAlignment;
-   codeCacheConfig._codeCacheFreeBlockRecylingEnabled = !TR::Options::getCmdLineOptions()->getOption(TR_DisableFreeCodeCacheBlockRecycling);
-   codeCacheConfig._largeCodePageSize = jitConfig->largeCodePageSize;
-   codeCacheConfig._largeCodePageFlags = jitConfig->largeCodePageFlags;
-   codeCacheConfig._maxNumberOfCodeCaches = maxNumberOfCodeCaches;
-   codeCacheConfig._canChangeNumCodeCaches = (TR::Options::getCmdLineOptions()->getNumCodeCachesToCreateAtStartup() <= 0);
+      if (jitConfig->codeCacheKB > jitConfig->codeCacheTotalKB)
+         {
+         /* Handle case where user has set codeCacheTotalKB smaller than codeCacheKB (e.g. -Xjit:codeTotal=256) by setting codeCacheKB = codeCacheTotalKB */
+         jitConfig->codeCacheKB = jitConfig->codeCacheTotalKB;
+         }
 
-   static char * segmentCarving = feGetEnv("TR_CodeCacheConsolidation");
-   bool useConsolidatedCodeCache = segmentCarving != NULL ||
-                                   TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheConsolidation);
+      if (jitConfig->dataCacheKB > jitConfig->dataCacheTotalKB)
+         {
+         /* Handle case where user has set dataCacheTotalKB smaller than dataCacheKB (e.g. -Xjit:dataTotal=256) by setting dataCacheKB = dataCacheTotalKB */
+         jitConfig->dataCacheKB = jitConfig->dataCacheTotalKB;
+         }
 
-   if (TR::Options::getCmdLineOptions()->getNumCodeCachesToCreateAtStartup() > 0) // user has specified option
-      numCodeCachesToCreateAtStartup = TR::Options::getCmdLineOptions()->getNumCodeCachesToCreateAtStartup();
-   // We cannot create at startup more code caches than the maximum
-   if (numCodeCachesToCreateAtStartup > maxNumberOfCodeCaches)
-      numCodeCachesToCreateAtStartup = maxNumberOfCodeCaches;
+      I_32 maxNumberOfCodeCaches = jitConfig->codeCacheTotalKB / jitConfig->codeCacheKB;
+      if (fe->isAOT_DEPRECATED_DO_NOT_USE())
+         maxNumberOfCodeCaches = 1;
 
-   firstCodeCache = codeCacheManager->initialize(useConsolidatedCodeCache, numCodeCachesToCreateAtStartup);
+      // setupCodeCacheParameters must stay before  TR::CodeCacheManager::initialize() because it needs trampolineCodeSize
+      setupCodeCacheParameters(&codeCacheConfig._trampolineCodeSize, &codeCacheConfig._mccCallbacks, &codeCacheConfig._numOfRuntimeHelpers, &codeCacheConfig._CCPreLoadedCodeSize);
 
-   // large code page size may have been updated by initialize(), so copy back to jitConfig
-   jitConfig->largeCodePageSize = (UDATA) codeCacheConfig.largeCodePageSize();
+      if (!TR_TranslationArtifactManager::initializeGlobalArtifactManager(jitConfig->translationArtifacts, jitConfig->javaVM))
+         return -1;
 
-   if (firstCodeCache == NULL)
-      return -1;
-   jitConfig->codeCache = firstCodeCache->j9segment();
-   ((TR_JitPrivateConfig *) jitConfig->privateConfig)->codeCacheManager = codeCacheManager; // for kca's benefit
+      codeCacheConfig._allowedToGrowCache = (javaVM->jitConfig->runtimeFlags & J9JIT_GROW_CACHES) != 0;
+      codeCacheConfig._lowCodeCacheThreshold = TR::Options::_lowCodeCacheThreshold;
+      codeCacheConfig._verboseCodeCache = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCodeCache);
+      codeCacheConfig._verbosePerformance = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance);
+      codeCacheConfig._verboseReclamation = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCodeCacheReclamation);
+      codeCacheConfig._doSanityChecks = TR::Options::getCmdLineOptions()->getOption(TR_CodeCacheSanityCheck);
+      codeCacheConfig._codeCacheTotalKB = jitConfig->codeCacheTotalKB;
+      codeCacheConfig._codeCacheKB = jitConfig->codeCacheKB;
+      codeCacheConfig._codeCachePadKB = jitConfig->codeCachePadKB;
+      codeCacheConfig._codeCacheAlignment = jitConfig->codeCacheAlignment;
+      codeCacheConfig._codeCacheFreeBlockRecylingEnabled = !TR::Options::getCmdLineOptions()->getOption(TR_DisableFreeCodeCacheBlockRecycling);
+      codeCacheConfig._largeCodePageSize = jitConfig->largeCodePageSize;
+      codeCacheConfig._largeCodePageFlags = jitConfig->largeCodePageFlags;
+      codeCacheConfig._maxNumberOfCodeCaches = maxNumberOfCodeCaches;
+      codeCacheConfig._canChangeNumCodeCaches = (TR::Options::getCmdLineOptions()->getNumCodeCachesToCreateAtStartup() <= 0);
 
-   if (fe->isAOT_DEPRECATED_DO_NOT_USE())
-      {
-      jitConfig->codeCache->heapAlloc = firstCodeCache->getCodeTop();
-#if defined(TR_TARGET_X86) && defined(TR_HOST_32BIT)
-      javaVM->jitConfig = (J9JITConfig *)jitConfig;
-      queryX86TargetCPUID(javaVM);
-#endif
+      static char * segmentCarving = feGetEnv("TR_CodeCacheConsolidation");
+      bool useConsolidatedCodeCache = segmentCarving != NULL ||
+                                      TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheConsolidation);
+
+      if (TR::Options::getCmdLineOptions()->getNumCodeCachesToCreateAtStartup() > 0) // user has specified option
+         numCodeCachesToCreateAtStartup = TR::Options::getCmdLineOptions()->getNumCodeCachesToCreateAtStartup();
+      // We cannot create at startup more code caches than the maximum
+      if (numCodeCachesToCreateAtStartup > maxNumberOfCodeCaches)
+         numCodeCachesToCreateAtStartup = maxNumberOfCodeCaches;
+
+      firstCodeCache = codeCacheManager->initialize(useConsolidatedCodeCache, numCodeCachesToCreateAtStartup);
+
+      // large code page size may have been updated by initialize(), so copy back to jitConfig
+      jitConfig->largeCodePageSize = (UDATA) codeCacheConfig.largeCodePageSize();
+
+      if (firstCodeCache == NULL)
+         return -1;
+      jitConfig->codeCache = firstCodeCache->j9segment();
+      ((TR_JitPrivateConfig *) jitConfig->privateConfig)->codeCacheManager = codeCacheManager; // for kca's benefit
+
+      if (fe->isAOT_DEPRECATED_DO_NOT_USE())
+         {
+         jitConfig->codeCache->heapAlloc = firstCodeCache->getCodeTop();
+   #if defined(TR_TARGET_X86) && defined(TR_HOST_32BIT)
+         javaVM->jitConfig = (J9JITConfig *)jitConfig;
+         queryX86TargetCPUID(javaVM);
+   #endif
+         }
+
+      /* allocate the data cache */
+      if (jitConfig->dataCacheKB < 1)
+         {
+         printf("<JIT: fatal error, data cache size must be at least 1 Kb>\n");
+         return -1;
+         }
+      if (!TR_DataCacheManager::initialize(jitConfig))
+         {
+         printf("{JIT: fatal error, failed to allocate %lu Kb data cache}\n", jitConfig->dataCacheKB);
+         return -1;
+         }
       }
 
    if (!fe->isAOT_DEPRECATED_DO_NOT_USE())
@@ -1417,18 +1464,6 @@ onLoadInternal(
             currentVMThread->codertTOC = (void *)jitConfig->pseudoTOC;
       #endif
 
-      }
-
-   /* allocate the data cache */
-   if (jitConfig->dataCacheKB < 1)
-      {
-      printf("<JIT: fatal error, data cache size must be at least 1 Kb>\n");
-      return -1;
-      }
-   if (!TR_DataCacheManager::initialize(jitConfig))
-      {
-      printf("{JIT: fatal error, failed to allocate %lu Kb data cache}\n", jitConfig->dataCacheKB);
-      return -1;
       }
 
    jitConfig->thunkLookUpNameAndSig = &j9ThunkLookupNameAndSig;
@@ -1614,24 +1649,27 @@ onLoadInternal(
          persistentMemory->getPersistentInfo()->setRuntimeInstrumentationRecompilationEnabled(true);
       }
 
-   TR_PersistentCHTable *chtable;
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
+      {
+      TR_PersistentCHTable *chtable;
 #if defined(JITSERVER_SUPPORT)
-   if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
-      {
-      chtable = new (PERSISTENT_NEW) JITServerPersistentCHTable(persistentMemory);
-      }
-   else if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-      {
-      chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory);
-      }
-   else
+      if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+         {
+         chtable = new (PERSISTENT_NEW) JITServerPersistentCHTable(persistentMemory);
+         }
+      else if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
+         {
+         chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory);
+         }
+      else
 #endif
-      {
-      chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory);
+         {
+         chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory);
+         }
+      if (chtable == NULL)
+         return -1;
+      persistentMemory->getPersistentInfo()->setPersistentCHTable(chtable);
       }
-   if (chtable == NULL)
-      return -1;
-   persistentMemory->getPersistentInfo()->setPersistentCHTable(chtable);
 
 #if defined(JITSERVER_SUPPORT)
    if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1649,27 +1649,24 @@ onLoadInternal(
          persistentMemory->getPersistentInfo()->setRuntimeInstrumentationRecompilationEnabled(true);
       }
 
-   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
-      {
-      TR_PersistentCHTable *chtable;
+   TR_PersistentCHTable *chtable;
 #if defined(JITSERVER_SUPPORT)
-      if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
-         {
-         chtable = new (PERSISTENT_NEW) JITServerPersistentCHTable(persistentMemory);
-         }
-      else if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
-         {
-         chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory);
-         }
-      else
-#endif
-         {
-         chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory);
-         }
-      if (chtable == NULL)
-         return -1;
-      persistentMemory->getPersistentInfo()->setPersistentCHTable(chtable);
+   if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      {
+      chtable = new (PERSISTENT_NEW) JITServerPersistentCHTable(persistentMemory);
       }
+   else if (persistentMemory->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
+      {
+      chtable = new (PERSISTENT_NEW) JITClientPersistentCHTable(persistentMemory);
+      }
+   else
+#endif
+      {
+      chtable = new (PERSISTENT_NEW) TR_PersistentCHTable(persistentMemory);
+      }
+   if (chtable == NULL)
+      return -1;
+   persistentMemory->getPersistentInfo()->setPersistentCHTable(chtable);
 
 #if defined(JITSERVER_SUPPORT)
    if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
@@ -1815,6 +1812,8 @@ onLoadInternal(
                   return -1;
             }
          }
+
+      jitConfig->methodsToDelete = NULL;
       }
 
    return 0;

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -83,6 +83,7 @@ typedef enum {
    compilationStreamVersionIncompatible            = 56,
    compilationStreamInterrupted                    = 57,
 #endif /* defined(JITSERVER_SUPPORT) */
+   compilationRetryAfterSomeTime                   = 58,
    /* please insert new codes before compilationMaxError which is used in jar2jxe to test the error codes range */
    /* If new codes are added then add the corresponding names in compilationErrorNames table in rossa.cpp */
    compilationMaxError /* must be the last one */

--- a/runtime/compiler/env/PersistentAllocator.cpp
+++ b/runtime/compiler/env/PersistentAllocator.cpp
@@ -32,17 +32,21 @@ PersistentAllocator::PersistentAllocator(const PersistentAllocatorKit &creationK
    _minimumSegmentSize(creationKit.minimumSegmentSize),
    _segmentAllocator(MEMORY_TYPE_JIT_PERSISTENT, creationKit.javaVM),
    _freeBlocks(),
-   _segments(SegmentContainerAllocator(RawAllocator(&creationKit.javaVM)))
+   _segments(SegmentContainerAllocator(RawAllocator(&creationKit.javaVM))),
+   _javaVM(&creationKit.javaVM)
    {
    }
 
 PersistentAllocator::~PersistentAllocator() throw()
    {
-   while (!_segments.empty())
+   if (!IS_RAM_CACHE_ON(_javaVM))
       {
-      J9MemorySegment &segment = _segments.front();
-      _segments.pop_front();
-      _segmentAllocator.deallocate(segment);
+      while (!_segments.empty())
+         {
+         J9MemorySegment &segment = _segments.front();
+         _segments.pop_front();
+         _segmentAllocator.deallocate(segment);
+         }
       }
    }
 

--- a/runtime/compiler/env/PersistentAllocator.hpp
+++ b/runtime/compiler/env/PersistentAllocator.hpp
@@ -99,6 +99,7 @@ private:
    typedef TR::typed_allocator<TR::reference_wrapper<J9MemorySegment>, TR::RawAllocator> SegmentContainerAllocator;
    typedef std::deque<TR::reference_wrapper<J9MemorySegment>, SegmentContainerAllocator> SegmentContainer;
    SegmentContainer _segments;
+   J9JavaVM *_javaVM;
    };
 
 }

--- a/runtime/compiler/env/PersistentAllocator.hpp
+++ b/runtime/compiler/env/PersistentAllocator.hpp
@@ -62,6 +62,8 @@ public:
       return !operator ==(left, right);
       }
 
+   void printSegments();
+
 private:
 
    // Persistent block header
@@ -100,6 +102,7 @@ private:
    typedef std::deque<TR::reference_wrapper<J9MemorySegment>, SegmentContainerAllocator> SegmentContainer;
    SegmentContainer _segments;
    J9JavaVM *_javaVM;
+   TR::RawAllocator _rawAllocator;
    };
 
 }

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -66,6 +66,25 @@ TR_PersistentCHTable::TR_PersistentCHTable(TR_PersistentMemory *trPersistentMemo
    _classes = static_cast<TR_LinkHead<TR_PersistentClassInfo> *>(static_cast<void *>(_buffer));
    }
 
+void
+TR_PersistentCHTable::destroy(TR_PersistentCHTable *pcht)
+   {
+   for (int32_t i = 0; i <= CLASSHASHTABLE_SIZE; ++i)
+      {
+      TR_PersistentClassInfo *cursor = pcht->_classes[i].getFirst();
+      while (cursor)
+         {
+         TR_PersistentClassInfo *next = cursor->getNext();
+
+         cursor->removeSubClasses();
+         jitPersistentFree(cursor);
+
+         cursor = next;
+         }
+      }
+   jitPersistentFree(pcht);
+   }
+
 
 void
 TR_PersistentCHTable::commitSideEffectGuards(TR::Compilation *comp)

--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -438,7 +438,9 @@ TR_ResolvedMethod * TR_PersistentCHTable::findSingleImplementer(
    if (implCount == 1)
       implementer =implArray[0];
 
-   if (implementer && comp->getOption(TR_UseSymbolValidationManager) && validate)
+   if (implementer
+       && (comp->getOption(TR_UseSymbolValidationManager) || IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM))
+       && validate)
       {
       TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
 
@@ -447,10 +449,18 @@ TR_ResolvedMethod * TR_PersistentCHTable::findSingleImplementer(
                                                                  cpIndexOrVftSlot,
                                                                  callerMethod->getPersistentIdentifier(),
                                                                  useGetResolvedInterfaceMethod);
-      if (validated)
-         SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+
+      if (IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM))
+         {
+         TR_ASSERT_FATAL(validated, "Add Validation Record should not fail...");
+         }
       else
-         implementer = NULL;
+         {
+         if (validated)
+            SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+         else
+            implementer = NULL;
+         }
       }
 
    return implementer;
@@ -488,7 +498,9 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
    if (implCount == 1)
       implementer = implArray[0];
 
-   if (implementer && comp->getOption(TR_UseSymbolValidationManager) && validate)
+   if (implementer
+       && (comp->getOption(TR_UseSymbolValidationManager) || IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM))
+       && validate)
       {
       TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
       bool validated = svm->addMethodFromSingleInterfaceImplementerRecord(implementer->getPersistentIdentifier(),
@@ -496,10 +508,17 @@ TR_PersistentCHTable::findSingleInterfaceImplementer(
                                                                           cpIndex,
                                                                           callerMethod->getPersistentIdentifier());
 
-      if (validated)
-         SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+      if (IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM))
+         {
+         TR_ASSERT_FATAL(validated, "Add Validation Record should not fail...");
+         }
       else
-         implementer = NULL;
+         {
+         if (validated)
+            SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+         else
+            implementer = NULL;
+         }
       }
 
    return implementer;
@@ -594,7 +613,9 @@ TR_PersistentCHTable::findSingleAbstractImplementer(
    if(implCount == 1)
       implementer = implArray[0];
 
-   if (implementer && comp->getOption(TR_UseSymbolValidationManager) && validate)
+   if (implementer
+       && (comp->getOption(TR_UseSymbolValidationManager) || IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM))
+       && validate)
       {
       TR::SymbolValidationManager *svm = comp->getSymbolValidationManager();
       bool validated = svm->addMethodFromSingleAbstractImplementerRecord(implementer->getPersistentIdentifier(),
@@ -602,10 +623,17 @@ TR_PersistentCHTable::findSingleAbstractImplementer(
                                                                          vftSlot,
                                                                          callerMethod->getPersistentIdentifier());
 
-      if (validated)
-         SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+      if (IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM))
+         {
+         TR_ASSERT_FATAL(validated, "Add Validation Record should not fail...");
+         }
       else
-         implementer = NULL;
+         {
+         if (validated)
+            SVM_ASSERT_ALREADY_VALIDATED(svm, implementer->classOfMethod());
+         else
+            implementer = NULL;
+         }
       }
 
    return implementer;
@@ -642,10 +670,20 @@ TR_PersistentCHTable::findSingleConcreteSubClass(
          }
       }
 
-   if (validate && comp->getOption(TR_UseSymbolValidationManager))
+   if (validate
+       && (comp->getOption(TR_UseSymbolValidationManager) || IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM)))
       {
-      if (!comp->getSymbolValidationManager()->addConcreteSubClassFromClassRecord(concreteSubClass, opaqueClass))
-         concreteSubClass = NULL;
+      bool validated = comp->getSymbolValidationManager()->addConcreteSubClassFromClassRecord(concreteSubClass, opaqueClass);
+
+      if (IS_RAM_CACHE_ON(comp->fej9()->getJ9JITConfig()->javaVM) && concreteSubClass)
+         {
+         TR_ASSERT_FATAL(validated, "Add Validation Record should not fail...");
+         }
+      else
+         {
+         if (!validated)
+            concreteSubClass = NULL;
+         }
       }
 
    return concreteSubClass;

--- a/runtime/compiler/env/PersistentCHTable.hpp
+++ b/runtime/compiler/env/PersistentCHTable.hpp
@@ -84,6 +84,8 @@ class TR_PersistentCHTable
    virtual void removeClass(TR_FrontEnd *, TR_OpaqueClassBlock *classId, TR_PersistentClassInfo *info, bool removeInfo);
    virtual void resetVisitedClasses(); // highly time consuming
 
+   static void destroy(TR_PersistentCHTable *pcht);
+
 #ifdef DEBUG
    void dumpStats(TR_FrontEnd *);
 #endif

--- a/runtime/compiler/env/RawAllocator.hpp
+++ b/runtime/compiler/env/RawAllocator.hpp
@@ -41,6 +41,8 @@ using J9::RawAllocator;
 #include <new>
 #include "env/TypedAllocator.hpp"
 #include "j9.h"
+#include "jvmimage.h"
+#include "jvmimageport.h"
 #undef min
 #undef max
 
@@ -68,7 +70,16 @@ public:
    void * allocate(size_t size, const std::nothrow_t& tag, void * hint = 0) throw()
       {
       PORT_ACCESS_FROM_JAVAVM(_javaVM);
-      return j9mem_allocate_memory(size, J9MEM_CATEGORY_JIT);
+      JVMIMAGEPORT_ACCESS_FROM_JAVAVM(_javaVM);
+
+      if (IS_COLD_RUN(_javaVM))
+         {
+         return imem_allocate_memory(size, J9MEM_CATEGORY_JIT);
+         }
+      else
+         {
+         return j9mem_allocate_memory(size, J9MEM_CATEGORY_JIT);
+         }
       }
 
    void * allocate(size_t size, void * hint = 0)
@@ -81,7 +92,16 @@ public:
    void deallocate(void * p, size_t size = 0) throw()
       {
       PORT_ACCESS_FROM_JAVAVM(_javaVM);
-      j9mem_free_memory(p);
+      JVMIMAGEPORT_ACCESS_FROM_JAVAVM(_javaVM);
+
+      if (IS_COLD_RUN(_javaVM))
+         {
+         imem_free_memory(p);
+         }
+      else
+         {
+         j9mem_free_memory(p);
+         }
       }
 
    friend bool operator ==(const RawAllocator &left, const RawAllocator &right)

--- a/runtime/compiler/env/RawAllocator.hpp
+++ b/runtime/compiler/env/RawAllocator.hpp
@@ -72,7 +72,7 @@ public:
       PORT_ACCESS_FROM_JAVAVM(_javaVM);
       JVMIMAGEPORT_ACCESS_FROM_JAVAVM(_javaVM);
 
-      if (IS_COLD_RUN(_javaVM))
+      if (IS_RAM_CACHE_ON(_javaVM))
          {
          return imem_allocate_memory(size, J9MEM_CATEGORY_JIT);
          }
@@ -94,7 +94,7 @@ public:
       PORT_ACCESS_FROM_JAVAVM(_javaVM);
       JVMIMAGEPORT_ACCESS_FROM_JAVAVM(_javaVM);
 
-      if (IS_COLD_RUN(_javaVM))
+      if (IS_RAM_CACHE_ON(_javaVM))
          {
          imem_free_memory(p);
          }

--- a/runtime/compiler/env/Startup.cpp
+++ b/runtime/compiler/env/Startup.cpp
@@ -59,6 +59,11 @@ bool initializeJIT(J9JavaVM *vm)
       {
       TR_PersistentMemory * persistentMemory = (TR_PersistentMemory *)vm->jitConfig->scratchSegment;
       TR::Compiler = (TR::CompilerEnv *)(((TR_CacheForImage *)vm->jitConfig->cacheForImage)->compilerEnv);
+      printf("CompilerEnv=%p, PersistentAllocator=%p, PersistentMemory = %p\n",
+             TR::Compiler,
+             &TR::Compiler->persistentAllocator(),
+             ((TR_CacheForImage *)vm->jitConfig->cacheForImage)->persistentMemory);
+      TR::Compiler->persistentAllocator().printSegments();
       }
 
    return true;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5219,6 +5219,8 @@ TR_ResolvedJ9Method::isInterpreted()
    {
    if (_fe->tossingCode())
       return true;
+   if (IS_RAM_CACHE_ON(_fe->getJ9JITConfig()->javaVM))
+      return true;
    return !(TR::CompilationInfo::isCompiled(ramMethod()));
    }
 

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -455,6 +455,8 @@ public:
    virtual TR_ResolvedMethod *     getResolvedInterfaceMethod( TR::Compilation *, TR_OpaqueClassBlock * classObject, int32_t cpIndex);
    virtual TR_ResolvedMethod *     getResolvedVirtualMethod( TR::Compilation *, TR_OpaqueClassBlock * classObject, int32_t virtualCallOffset, bool ignoreRtResolve = true);
 
+   virtual TR_OpaqueClassBlock  *  getDeclaringClassFromFieldOrStatic( TR::Compilation *comp, int32_t cpIndex);
+
    virtual bool                    virtualMethodIsOverridden();
    virtual void                    setVirtualMethodIsOverridden();
    virtual void *                  addressContainingIsOverriddenBit();

--- a/runtime/compiler/exceptions/RuntimeFailure.hpp
+++ b/runtime/compiler/exceptions/RuntimeFailure.hpp
@@ -79,6 +79,11 @@ class EnforceProfiling : public virtual TR::InsufficientlyAggressiveCompilation
    {
    virtual const char* what() const throw() { return "Enforce Profiling"; }
    };
+
+class RetryLoadAfterSomeTime : public virtual TR::CompilationException
+   {
+   virtual const char* what() const throw() { return "Retry Load After Some Time"; }
+   };
 }
 
 #endif // RUNTIME_FAILURE

--- a/runtime/compiler/infra/J9Monitor.hpp
+++ b/runtime/compiler/infra/J9Monitor.hpp
@@ -73,6 +73,8 @@ class Monitor : public TR_Link0<TR::Monitor>
    // Dangerous: do not use this routine, except for thread exit
    void *getVMMonitor() { return (void*)_monitor; }
 
+   void *getVMMonitorAddr() { return (void *)(&_monitor); }
+
    private:
 
    friend class J9::MonitorTable;

--- a/runtime/compiler/infra/J9MonitorTable.cpp
+++ b/runtime/compiler/infra/J9MonitorTable.cpp
@@ -166,6 +166,10 @@ J9::MonitorTable::removeAndDestroy(TR::Monitor *monitor)
    {
    TR::MonitorTable *table = TR::MonitorTable::get();
    if (!table) return;
+
+   if (IS_RAM_CACHE_ON(table->_javaVM))
+      return;
+
    PORT_ACCESS_FROM_PORT(table->_portLib);
    // search the table for my monitor
    {
@@ -201,6 +205,9 @@ J9::MonitorTable::free()
    {
    TR::MonitorTable *table = TR::MonitorTable::get();
    if (!table) return;
+
+   if (IS_RAM_CACHE_ON(table->_javaVM))
+      return;
 
    PORT_ACCESS_FROM_PORT(table->_portLib);
 

--- a/runtime/compiler/infra/J9MonitorTable.hpp
+++ b/runtime/compiler/infra/J9MonitorTable.hpp
@@ -80,6 +80,7 @@ class OMR_EXTENSIBLE MonitorTable : public OMR::MonitorTableConnector
    void insert(TR::Monitor *monitor);
 
    J9PortLibrary *_portLib;
+   J9JavaVM      *_javaVM;
    TR_LinkHead0<TR::Monitor> _monitors;
 
    TR::Monitor _tableMonitor;

--- a/runtime/compiler/runtime/DataCache.hpp
+++ b/runtime/compiler/runtime/DataCache.hpp
@@ -402,6 +402,7 @@ public:
    // static methods
    static TR_DataCacheManager* initialize(J9JITConfig * jitConfig);
    static TR_DataCacheManager* getManager() { return _dataCacheManager; }
+   static void setManager(TR_DataCacheManager *dcm) { _dataCacheManager = dcm; }
    static void destroyManager();
    static void copyDataCacheAllocation (J9JITDataCacheHeader *dest, J9JITDataCacheHeader *src);
 #if defined(TR_HOST_64BIT)

--- a/runtime/compiler/runtime/DataCache.hpp
+++ b/runtime/compiler/runtime/DataCache.hpp
@@ -396,6 +396,8 @@ public:
       convertDataCachesToAllocations();
       }
 
+   TR::Monitor * getMonitor() { return _mutex; }
+
    virtual void printStatistics();
 
 

--- a/runtime/compiler/runtime/HookHelpers.cpp
+++ b/runtime/compiler/runtime/HookHelpers.cpp
@@ -42,6 +42,9 @@
 #include "env/VMJ9.h"
 #include "env/j9method.h"
 
+#include "jvmimage.h"
+#include "jvmimageport.h"
+
 namespace  {
 
 #if defined(RECLAMATION_DEBUG)
@@ -435,7 +438,8 @@ void freeFastWalkCache(J9VMThread *vmThread, J9JITExceptionTable *metaData)
          if (mapTable && mapTable != (void *)-1)
             {
             PORT_ACCESS_FROM_VMC(vmThread);
-            j9mem_free_memory(mapTable);
+            if (!IS_RAM_CACHE_ON(vmThread->javaVM))
+               j9mem_free_memory(mapTable);
             }
          ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->setMapTable(NULL);
          }

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -541,6 +541,9 @@ J9::CodeCacheManager::setupMemorySegmentFromRepository(uint8_t *start,
 void
 J9::CodeCacheManager::freeMemorySegment(TR::CodeCacheMemorySegment *segment)
    {
+   if (IS_RAM_CACHE_ON(_jitConfig->javaVM))
+      return;
+
    segment->free(self());
    }
 

--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -61,6 +61,7 @@ public:
    void *operator new(size_t s, TR::CodeCacheManager *m) { return m; }
 
    static TR::CodeCacheManager *instance() { return _codeCacheManager; }
+   static void setInstance(TR::CodeCacheManager *ccm) { _codeCacheManager = ccm; }
    static J9JITConfig *jitConfig()         { return _jitConfig; }
    static J9JavaVM *javaVM()               { return _javaVM; }
 

--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -63,7 +63,9 @@ public:
    static TR::CodeCacheManager *instance() { return _codeCacheManager; }
    static void setInstance(TR::CodeCacheManager *ccm) { _codeCacheManager = ccm; }
    static J9JITConfig *jitConfig()         { return _jitConfig; }
+   static void setJitConfig(J9JITConfig *jitConfig) { _jitConfig = jitConfig; }
    static J9JavaVM *javaVM()               { return _javaVM; }
+   static void setJavaVM(J9JavaVM *javaVM) { _javaVM = javaVM; }
 
    TR_FrontEnd *fe();
    TR_J9VMBase *fej9();
@@ -71,6 +73,8 @@ public:
    TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
 
    void addCodeCache(TR::CodeCache *codeCache);
+
+   bool registerCodeCaches();
 
    TR::CodeCacheMemorySegment *allocateCodeCacheSegment(size_t segmentSize,
                                                         size_t &codeCacheSizeToAllocate,

--- a/runtime/compiler/runtime/J9CodeCacheMemorySegment.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheMemorySegment.cpp
@@ -60,6 +60,9 @@ void
 J9::CodeCacheMemorySegment::free(TR::CodeCacheManager *manager)
    {
    J9JavaVM *javaVM = manager->javaVM();
+   if (IS_RAM_CACHE_ON(javaVM))
+      return;
+
    javaVM->internalVMFunctions->freeMemorySegment(javaVM, _segment, 1);
    new (reinterpret_cast<TR::CodeCacheMemorySegment *>(this)) TR::CodeCacheMemorySegment();
    }

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -96,6 +96,15 @@ void fixPersistentMethodInfo(void *table, bool isJITClientAOTLoad = false);
 void fixupMethodInfoAddressInCodeCache(void *startPC, void *bodyInfo);
 #endif
 
+typedef struct TR_CacheForImage
+   {
+   void *persistentMemory;
+   void *monitorTable;
+   void *compilerEnv;
+   void *codeCacheManager;
+   void *dataCacheManager;
+   void *globalFrontend;
+   } TR_CacheForImage;
 
 typedef struct TR_InlinedSiteLinkedListEntry
    {

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -69,6 +69,9 @@
 #include "control/CompilationRuntime.hpp"
 #include "runtime/HWProfiler.hpp"
 
+#include "jvmimage.h"
+#include "jvmimageport.h"
+
 typedef std::set<TR_GCStackMap*, std::less<TR_GCStackMap*>, TR::typed_allocator<TR_GCStackMap*, TR::Region&>> GCStackMapSet;
 
 struct TR_StackAtlasStats
@@ -1591,6 +1594,13 @@ createMethodMetaData(
          {
          // Insert trace point here for insertion failure
          }
+      TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+      if (IS_RAM_CACHE_ON(compInfo->getJITConfig()->javaVM))
+         {
+         void * j9method = static_cast<void *>(vmMethod->getPersistentIdentifier());
+         compInfo->persistentMemory()->addMethodToMap(j9method, (void *)data);
+         }
+
       if (vm->isAnonymousClass( ((TR_ResolvedJ9Method*)vmMethod)->romClassPtr()))
          {
          J9Class *j9clazz = ((TR_ResolvedJ9Method*)vmMethod)->constantPoolHdr();

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1477,6 +1477,15 @@ createMethodMetaData(
    data->tempOffset = comp->cg()->getStackAtlas()->getNumberOfPendingPushSlots();
    data->size = tableSize;
 
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+   if (IS_RAM_CACHE_ON(compInfo->getJITConfig()->javaVM))
+      {
+      JVMIMAGEPORT_ACCESS_FROM_JAVAVM(compInfo->getJITConfig()->javaVM);
+      UDATA size = (data->endPC - data->startPC);
+      data->shadowCodeStart = imem_allocate_memory(size, J9MEM_CATEGORY_JIT);
+      memcpy(data->shadowCodeStart, (void *)data->startPC, size);
+      }
+
    data->gcStackAtlas = createStackAtlas(
          vm,
          comp->cg(),
@@ -1594,7 +1603,7 @@ createMethodMetaData(
          {
          // Insert trace point here for insertion failure
          }
-      TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+
       if (IS_RAM_CACHE_ON(compInfo->getJITConfig()->javaVM))
          {
          void * j9method = static_cast<void *>(vmMethod->getPersistentIdentifier());

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1590,6 +1590,19 @@ createMethodMetaData(
 
    populateInlineCalls(comp, vm, data, callSiteCursor, numberOfMapBytes);
 
+   if (IS_RAM_CACHE_ON(compInfo->getJITConfig()->javaVM))
+      {
+      uintptrj_t sizeOfReloBuffer = comp->getSymbolValidationManager()->getTotalSizeOfRecords();
+      struct ReloBuffer *reloBuffer =
+            (struct ReloBuffer *)compInfo->persistentMemory()->allocatePersistentMemory(sizeOfReloBuffer + sizeof(uintptrj_t));
+      reloBuffer->size = sizeOfReloBuffer;
+
+      if (!comp->getSymbolValidationManager()->writeRecordsToBuffer((void *)reloBuffer->buffer, reloBuffer->size))
+         return NULL;
+
+      data->reloBuffer = (void *)reloBuffer;
+      }
+
    if (!(vm->_jitConfig->runtimeFlags & J9JIT_TOSS_CODE) && !vm->isAOT_DEPRECATED_DO_NOT_USE()
 #if defined(JITSERVER_SUPPORT)
       && !comp->isOutOfProcessCompilation()

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1621,6 +1621,9 @@ createMethodMetaData(
          {
          void * j9method = static_cast<void *>(vmMethod->getPersistentIdentifier());
          compInfo->persistentMemory()->addMethodToMap(j9method, (void *)data);
+
+         if (TR::Options::_verboseImage > 0)
+            printf("Added <%p, %p> to map\n", j9method, (void *)data);
          }
 
       if (vm->isAnonymousClass( ((TR_ResolvedJ9Method*)vmMethod)->romClassPtr()))

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -30,6 +30,9 @@
 #include "rommeth.h"
 #include "env/jittypes.h"
 
+#include "jvmimage.h"
+#include "jvmimageport.h"
+
 #define FASTWALK 1
 
 #define FASTWALK_CACHESIZE 2
@@ -144,7 +147,12 @@ static JITINLINE TR_StackMapTable * initializeMapTable(J9JavaVM * javaVM, J9TR_M
    if (i._stackAtlas->numberOfMaps > threshold)
       {
       PORT_ACCESS_FROM_JAVAVM(javaVM);
-      mapTable = (TR_StackMapTable *) j9mem_allocate_memory(concreteMapCount * sizeof(TR_MapTableEntry) + sizeof(TR_StackMapTable), J9MEM_CATEGORY_JIT);
+      JVMIMAGEPORT_ACCESS_FROM_JAVAVM(javaVM);
+
+      if (IS_RAM_CACHE_ON(javaVM))
+         mapTable = (TR_StackMapTable *) imem_allocate_memory(concreteMapCount * sizeof(TR_MapTableEntry) + sizeof(TR_StackMapTable), J9MEM_CATEGORY_JIT);
+      else
+         mapTable = (TR_StackMapTable *) j9mem_allocate_memory(concreteMapCount * sizeof(TR_MapTableEntry) + sizeof(TR_StackMapTable), J9MEM_CATEGORY_JIT);
 
       if (mapTable)
          {

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -150,7 +150,6 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
      _seenSymbolsSet((SeenSymbolsComparator()), _region),
      _wellKnownClasses(_region),
      _loadersOkForWellKnownClasses(_region),
-     _jlthrowable(_fej9->getSystemClassFromClassName(jlthrowableName, (int32_t)strlen(jlthrowableName))),
      _totalSizeOfRecords(0)
    {
    assertionsAreFatal(); // Acknowledge the env var whether or not assertions fail
@@ -180,6 +179,9 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
       _alreadyGeneratedRecords.insert(
          new (_region) ArrayClassFromComponentClassRecord(arrayClass, component));
       }
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      _jlthrowable = _fej9->getSystemClassFromClassName(jlthrowableName, (int32_t)strlen(jlthrowableName));
    }
 
 void

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -32,13 +32,97 @@
 #include "runtime/RelocationRuntime.hpp"
 #include "runtime/SymbolValidationManager.hpp"
 
-#include "j9protos.h"
-
 #if defined (_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 
 static const char * const jlthrowableName = "java/lang/Throwable";
+
+static uintptrj_t getSizeOfRecord(TR_ExternalRelocationTargetKind kind)
+   {
+   switch (kind)
+      {
+      case TR_ValidateClassByName:
+         return sizeof(TR::ClassByNameRecord);
+         break;
+
+      case TR_ValidateClassFromCP:
+         return sizeof(TR::ClassFromCPRecord);
+         break;
+
+      case TR_ValidateDefiningClassFromCP:
+         return sizeof(TR::DefiningClassFromCPRecord);
+         break;
+
+      case TR_ValidateStaticClassFromCP:
+         return sizeof(TR::StaticClassFromCPRecord);
+         break;
+
+      case TR_ValidateSystemClassByName:
+         return sizeof(TR::SystemClassByNameRecord);
+         break;
+
+      case TR_ValidateClassFromITableIndexCP:
+         return sizeof(TR::ClassFromITableIndexCPRecord);
+         break;
+
+      case TR_ValidateDeclaringClassFromFieldOrStatic:
+         return sizeof(TR::DeclaringClassFromFieldOrStaticRecord);
+         break;
+
+      case TR_ValidateStaticMethodFromCP:
+         return sizeof(TR::StaticMethodFromCPRecord);
+         break;
+
+      case TR_ValidateSpecialMethodFromCP:
+         return sizeof(TR::SpecialMethodFromCPRecord);
+         break;
+
+      case TR_ValidateVirtualMethodFromCP:
+         return sizeof(TR::VirtualMethodFromCPRecord);
+         break;
+
+      case TR_ValidateVirtualMethodFromOffset:
+         return sizeof(TR::VirtualMethodFromOffsetRecord);
+         break;
+
+      case TR_ValidateInterfaceMethodFromCP:
+         return sizeof(TR::InterfaceMethodFromCPRecord);
+         break;
+
+      case TR_ValidateImproperInterfaceMethodFromCP:
+         return sizeof(TR::ImproperInterfaceMethodFromCPRecord);
+         break;
+
+      case TR_ValidateMethodFromClassAndSig:
+         return sizeof(TR::MethodFromClassAndSigRecord);
+         break;
+
+      case TR_ValidateMethodFromSingleImplementer:
+         return sizeof(TR::MethodFromSingleImplementer);
+         break;
+
+      case TR_ValidateMethodFromSingleInterfaceImplementer:
+         return sizeof(TR::MethodFromSingleInterfaceImplementer);
+         break;
+
+      case TR_ValidateMethodFromSingleAbstractImplementer:
+         return sizeof(TR::MethodFromSingleAbstractImplementer);
+         break;
+
+      case TR_ValidateConcreteSubClassFromClass:
+         return sizeof(TR::ConcreteSubClassFromClassRecord);
+         break;
+
+      case TR_ValidateClassInfoIsInitialized:
+         return sizeof(TR::ClassInfoIsInitialized);
+         break;
+
+      default:
+         SVM_ASSERT(false, "Called getSizeOfRecord with invalid kind %d", kind);
+         return 0;
+      }
+   }
 
 TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_ResolvedMethod *compilee)
    : _symbolID(FIRST_ID),
@@ -55,6 +139,7 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
         TR_J9VMBase::DEFAULT_VM)),
      _trMemory(_comp->trMemory()),
      _chTable(_comp->getPersistentInfo()->getPersistentCHTable()),
+     _javaVM(_fej9->getJ9JITConfig()->javaVM),
      _rootClass(compilee->classOfMethod()),
      _wellKnownClassChainOffsets(NULL),
      _symbolValidationRecords(_region),
@@ -65,7 +150,8 @@ TR::SymbolValidationManager::SymbolValidationManager(TR::Region &region, TR_Reso
      _seenSymbolsSet((SeenSymbolsComparator()), _region),
      _wellKnownClasses(_region),
      _loadersOkForWellKnownClasses(_region),
-     _jlthrowable(_fej9->getSystemClassFromClassName(jlthrowableName, (int32_t)strlen(jlthrowableName)))
+     _jlthrowable(_fej9->getSystemClassFromClassName(jlthrowableName, (int32_t)strlen(jlthrowableName))),
+     _totalSizeOfRecords(0)
    {
    assertionsAreFatal(); // Acknowledge the env var whether or not assertions fail
 
@@ -108,6 +194,9 @@ TR::SymbolValidationManager::defineGuaranteedID(void *symbol, TR::SymbolType typ
 bool
 TR::SymbolValidationManager::isClassWorthRemembering(TR_OpaqueClassBlock *clazz)
    {
+   if (IS_RAM_CACHE_ON(_javaVM))
+      return true;
+
    if (!_jlthrowable)
       _jlthrowable = _fej9->getSystemClassFromClassName(jlthrowableName, (int32_t)strlen(jlthrowableName));
 
@@ -177,48 +266,59 @@ TR::SymbolValidationManager::populateWellKnownClasses()
          traceMsg(_comp, "well-known class %s not found\n", name);
       else if (!_fej9->isPublicClass(wkClass))
          traceMsg(_comp, "well-known class %s is not public\n", name);
-      else
+      else if (!IS_RAM_CACHE_ON(_javaVM))
          chain = _fej9->sharedCache()->rememberClass(wkClass);
 
-      if (chain == NULL)
+      if (!IS_RAM_CACHE_ON(_javaVM))
          {
-         traceMsg(_comp, "no class chain for well-known class %s\n", name);
-         SVM_ASSERT_NONFATAL(
-            i >= REQUIRED_WELL_KNOWN_CLASS_COUNT,
-            "failed to remember required class %s\n",
-            name);
+         if (chain == NULL)
+            {
+            traceMsg(_comp, "no class chain for well-known class %s\n", name);
+            SVM_ASSERT_NONFATAL(
+               i >= REQUIRED_WELL_KNOWN_CLASS_COUNT,
+               "failed to remember required class %s\n",
+               name);
+            continue;
+            }
+
+         if (wkClass != _rootClass)
+            defineGuaranteedID(wkClass, TR::SymbolType::typeClass);
+
+         includedClasses |= 1 << i;
+         *nextClassChainOffset++ =
+            (uintptrj_t)_fej9->sharedCache()->offsetInSharedCacheFromPointer(chain);
+         }
+      else if (wkClass == NULL)
+         {
          continue;
          }
 
-      if (wkClass != _rootClass)
-         defineGuaranteedID(wkClass, TR::SymbolType::typeClass);
-
-      includedClasses |= 1 << i;
-      _wellKnownClasses.push_back(wkClass);
-      *nextClassChainOffset++ =
-         (uintptrj_t)_fej9->sharedCache()->offsetInSharedCacheFromPointer(chain);
+      _wellKnownClasses.push_back(wkClass);      
       }
 
-   *classCount = _wellKnownClasses.size();
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      *classCount = _wellKnownClasses.size();
 
-   char key[128];
-   snprintf(key, sizeof (key), "AOTWellKnownClasses:%x", includedClasses);
+      char key[128];
+      snprintf(key, sizeof (key), "AOTWellKnownClasses:%x", includedClasses);
 
-   J9SharedDataDescriptor dataDescriptor;
-   dataDescriptor.address = (U_8*)classChainOffsets;
-   dataDescriptor.length = (1 + _wellKnownClasses.size()) * sizeof (classChainOffsets[0]);
-   dataDescriptor.type = J9SHR_DATA_TYPE_JITHINT;
-   dataDescriptor.flags = 0;
+      J9SharedDataDescriptor dataDescriptor;
+      dataDescriptor.address = (U_8*)classChainOffsets;
+      dataDescriptor.length = (1 + _wellKnownClasses.size()) * sizeof (classChainOffsets[0]);
+      dataDescriptor.type = J9SHR_DATA_TYPE_JITHINT;
+      dataDescriptor.flags = 0;
 
-   _wellKnownClassChainOffsets =
-      _fej9->sharedCache()->storeSharedData(
-         _vmThread,
-         key,
-         &dataDescriptor);
+      _wellKnownClassChainOffsets =
+         _fej9->sharedCache()->storeSharedData(
+            _vmThread,
+            key,
+            &dataDescriptor);
 
-   SVM_ASSERT_NONFATAL(
-      _wellKnownClassChainOffsets != NULL,
-      "Failed to store well-known classes' class chains");
+      SVM_ASSERT_NONFATAL(
+         _wellKnownClassChainOffsets != NULL,
+         "Failed to store well-known classes' class chains");
+      }
 
 #undef WELL_KNOWN_CLASS_COUNT
    }
@@ -459,10 +559,15 @@ TR::SymbolValidationManager::appendNewRecord(void *symbol, TR::SymbolValidationR
    _symbolValidationRecords.push_front(record);
    _alreadyGeneratedRecords.insert(record);
 
-   record->printFields();
-   traceMsg(_comp, "\tkind=%d\n", record->_kind);
-   traceMsg(_comp, "\tid=%d\n", (uint32_t)getIDFromSymbol(symbol));
-   traceMsg(_comp, "\n");
+   _totalSizeOfRecords += getSizeOfRecord(record->_kind);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      record->printFields();
+      traceMsg(_comp, "\tkind=%d\n", record->_kind);
+      traceMsg(_comp, "\tid=%d\n", (uint32_t)getIDFromSymbol(symbol));
+      traceMsg(_comp, "\n");
+      }
    }
 
 void
@@ -552,11 +657,13 @@ TR::SymbolValidationManager::addClassRecord(TR_OpaqueClassBlock *clazz, TR::Clas
       }
 
    ClassChainInfo chainInfo;
-   if (!getClassChainInfo(clazz, record, chainInfo))
+   if (!IS_RAM_CACHE_ON(_javaVM) && !getClassChainInfo(clazz, record, chainInfo))
       return false;
 
    appendNewRecord(clazz, record); // The class is defined by the original record
-   appendClassChainInfoRecords(clazz, chainInfo);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      appendClassChainInfoRecords(clazz, chainInfo);
+
    return true;
    }
 
@@ -571,7 +678,11 @@ TR::SymbolValidationManager::addClassRecordWithChain(TR::ClassValidationRecordWi
 
    if (!_fej9->isPrimitiveClass(record->_class))
       {
-      record->_classChain = _fej9->sharedCache()->rememberClass(record->_class);
+      if (!IS_RAM_CACHE_ON(_javaVM))
+         record->_classChain = _fej9->sharedCache()->rememberClass(record->_class);
+      else
+         record->_classChain = (void *)(((J9Class *)record->_class)->romClass);
+
       if (record->_classChain == NULL)
          {
          _region.deallocate(record);
@@ -581,7 +692,9 @@ TR::SymbolValidationManager::addClassRecordWithChain(TR::ClassValidationRecordWi
       appendRecordIfNew(record->_class, record);
       }
 
-   addMultipleArrayRecords(record->_class, arrayDims);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      addMultipleArrayRecords(record->_class, arrayDims);
+
    return true;
    }
 
@@ -611,11 +724,13 @@ TR::SymbolValidationManager::addMethodRecord(TR::MethodValidationRecord *record)
       }
 
    ClassChainInfo chainInfo;
-   if (!getClassChainInfo(record->definingClass(_fej9), record, chainInfo))
+   if (!IS_RAM_CACHE_ON(_javaVM) && !getClassChainInfo(record->definingClass(_fej9), record, chainInfo))
       return false;
 
    appendNewRecord(record->_method, record);
-   appendClassChainInfoRecords(record->definingClass(), chainInfo);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      appendClassChainInfoRecords(record->definingClass(), chainInfo);
+
    return true;
    }
 
@@ -647,10 +762,13 @@ TR::SymbolValidationManager::skipFieldRefClassRecord(
 bool
 TR::SymbolValidationManager::addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR_OpaqueClassBlock *beholder)
    {
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
-   if (isWellKnownClass(clazz))
-      return true;
-   else if (clazz == beholder)
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+      if (isWellKnownClass(clazz))
+         return true;
+      }
+   if (clazz == beholder)
       return true;
    else if (anyClassFromCPRecordExists(clazz, beholder))
       return true; // already have an equivalent ClassFromCP
@@ -661,6 +779,8 @@ TR::SymbolValidationManager::addClassByNameRecord(TR_OpaqueClassBlock *clazz, TR
 bool
 TR::SymbolValidationManager::addProfiledClassRecord(TR_OpaqueClassBlock *clazz)
    {
+   SVM_ASSERT(!IS_RAM_CACHE_ON(_javaVM), "Calling addProfiledClassRecord in Image mode\n");
+
    // check that clazz is non-null before trying to rememberClass
    if (shouldNotDefineSymbol(clazz))
       return inHeuristicRegion();
@@ -686,10 +806,13 @@ TR::SymbolValidationManager::addClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9
       return true; // to make sure not to modify _classesFromAnyCPIndex
 
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
-   if (isWellKnownClass(clazz))
-      return true;
-   else if (clazz == beholder)
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+      if (isWellKnownClass(clazz))
+         return true;
+      }
+   if (clazz == beholder)
       return true;
 
    ClassByNameRecord byName(clazz, beholder);
@@ -712,7 +835,10 @@ bool
 TR::SymbolValidationManager::addDefiningClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex, bool isStatic)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    if (skipFieldRefClassRecord(clazz, beholder, cpIndex))
       return true;
    else
@@ -723,7 +849,10 @@ bool
 TR::SymbolValidationManager::addStaticClassFromCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, uint32_t cpIndex)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    if (skipFieldRefClassRecord(clazz, beholder, cpIndex))
        return true;
     else
@@ -733,14 +862,18 @@ TR::SymbolValidationManager::addStaticClassFromCPRecord(TR_OpaqueClassBlock *cla
 bool
 TR::SymbolValidationManager::addArrayClassFromComponentClassRecord(TR_OpaqueClassBlock *arrayClass, TR_OpaqueClassBlock *componentClass)
    {
+   SVM_ASSERT(!IS_RAM_CACHE_ON(_javaVM), "Calling addArrayClassFromComponentClassRecord in Image mode\n");
+
    // Class chain validation for the base component type is already taken care of
    SVM_ASSERT_ALREADY_VALIDATED(this, componentClass);
+
    return addVanillaRecord(arrayClass, new (_region) ArrayClassFromComponentClassRecord(arrayClass, componentClass));
    }
 
 bool
 TR::SymbolValidationManager::addSuperClassFromClassRecord(TR_OpaqueClassBlock *superClass, TR_OpaqueClassBlock *childClass)
    {
+   SVM_ASSERT(!IS_RAM_CACHE_ON(_javaVM), "Calling addSuperClassFromClassRecord in Image mode\n");
    SVM_ASSERT_ALREADY_VALIDATED(this, childClass);
    return addClassRecord(superClass, new (_region) SuperClassFromClassRecord(superClass, childClass));
    }
@@ -748,6 +881,7 @@ TR::SymbolValidationManager::addSuperClassFromClassRecord(TR_OpaqueClassBlock *s
 bool
 TR::SymbolValidationManager::addClassInstanceOfClassRecord(TR_OpaqueClassBlock *classOne, TR_OpaqueClassBlock *classTwo, bool objectTypeIsFixed, bool castTypeIsFixed, bool isInstanceOf)
    {
+   SVM_ASSERT(!IS_RAM_CACHE_ON(_javaVM), "Calling addClassInstanceOfClassRecord in Image mode\n");
    // Not using addClassRecord() because this doesn't define a class symbol. We
    // can pass either class as the symbol because neither will get a fresh ID
    SVM_ASSERT_ALREADY_VALIDATED(this, classOne);
@@ -778,7 +912,9 @@ bool
 TR::SymbolValidationManager::addClassFromITableIndexCPRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    return addClassRecord(clazz, new (_region) ClassFromITableIndexCPRecord(clazz, beholder, cpIndex));
    }
 
@@ -786,7 +922,10 @@ bool
 TR::SymbolValidationManager::addDeclaringClassFromFieldOrStaticRecord(TR_OpaqueClassBlock *clazz, J9ConstantPool *constantPoolOfBeholder, int32_t cpIndex)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(constantPoolOfBeholder);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    if (skipFieldRefClassRecord(clazz, beholder, cpIndex))
       return true;
    else
@@ -796,6 +935,8 @@ TR::SymbolValidationManager::addDeclaringClassFromFieldOrStaticRecord(TR_OpaqueC
 bool
 TR::SymbolValidationManager::addConcreteSubClassFromClassRecord(TR_OpaqueClassBlock *childClass, TR_OpaqueClassBlock *superClass)
    {
+   SVM_ASSERT(!IS_RAM_CACHE_ON(_javaVM), "Calling addConcreteSubClassFromClassRecord in Image mode\n");
+
    SVM_ASSERT_ALREADY_VALIDATED(this, superClass);
    return addClassRecord(childClass, new (_region) ConcreteSubClassFromClassRecord(childClass, superClass));
    }
@@ -803,6 +944,8 @@ TR::SymbolValidationManager::addConcreteSubClassFromClassRecord(TR_OpaqueClassBl
 bool
 TR::SymbolValidationManager::addMethodFromClassRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, uint32_t index)
    {
+   SVM_ASSERT(!IS_RAM_CACHE_ON(_javaVM), "Calling addMethodFromClassRecord in Image mode\n");
+
    // In case index == -1, check that method is non-null up front, before searching.
    if (shouldNotDefineSymbol(method))
       return inHeuristicRegion();
@@ -834,7 +977,10 @@ bool
 TR::SymbolValidationManager::addStaticMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(cp);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    return addMethodRecord(new (_region) StaticMethodFromCPRecord(method, beholder, cpIndex));
    }
 
@@ -842,7 +988,10 @@ bool
 TR::SymbolValidationManager::addSpecialMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(cp);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    return addMethodRecord(new (_region) SpecialMethodFromCPRecord(method, beholder, cpIndex));
    }
 
@@ -850,14 +999,18 @@ bool
 TR::SymbolValidationManager::addVirtualMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(cp);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    return addMethodRecord(new (_region) VirtualMethodFromCPRecord(method, beholder, cpIndex));
    }
 
 bool
 TR::SymbolValidationManager::addVirtualMethodFromOffsetRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, int32_t virtualCallOffset, bool ignoreRtResolve)
    {
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
 
    // Only need one bit, but it really should be a multiple of the pointer size
    SVM_ASSERT((virtualCallOffset & 1) == 0, "virtualCallOffset must be even");
@@ -871,8 +1024,12 @@ TR::SymbolValidationManager::addVirtualMethodFromOffsetRecord(TR_OpaqueMethodBlo
 bool
 TR::SymbolValidationManager::addInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *beholder, TR_OpaqueClassBlock *lookup, int32_t cpIndex)
    {
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
-   SVM_ASSERT_ALREADY_VALIDATED(this, lookup);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+      SVM_ASSERT_ALREADY_VALIDATED(this, lookup);
+      }
+
    return addMethodRecord(new (_region) InterfaceMethodFromCPRecord(method, beholder, lookup, cpIndex));
    }
 
@@ -880,7 +1037,10 @@ bool
 TR::SymbolValidationManager::addImproperInterfaceMethodFromCPRecord(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex)
    {
    TR_OpaqueClassBlock *beholder = _fej9->getClassFromCP(cp);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+
    return addMethodRecord(new (_region) ImproperInterfaceMethodFromCPRecord(method, beholder, cpIndex));
    }
 
@@ -891,8 +1051,12 @@ TR::SymbolValidationManager::addMethodFromClassAndSignatureRecord(TR_OpaqueMetho
    if (shouldNotDefineSymbol(method))
       return inHeuristicRegion();
 
-   SVM_ASSERT_ALREADY_VALIDATED(this, lookupClass);
-   SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(this, lookupClass);
+      SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
+      }
+
    return addMethodRecord(new (_region) MethodFromClassAndSigRecord(method, lookupClass, beholder));
    }
 
@@ -903,8 +1067,12 @@ TR::SymbolValidationManager::addMethodFromSingleImplementerRecord(TR_OpaqueMetho
                                                                   TR_OpaqueMethodBlock *callerMethod,
                                                                   TR_YesNoMaybe useGetResolvedInterfaceMethod)
    {
-   SVM_ASSERT_ALREADY_VALIDATED(this, thisClass);
-   SVM_ASSERT_ALREADY_VALIDATED(this, callerMethod);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(this, thisClass);
+      SVM_ASSERT_ALREADY_VALIDATED(this, callerMethod);
+      }
+
    return addMethodRecord(new (_region) MethodFromSingleImplementer(method, thisClass, cpIndexOrVftSlot, callerMethod, useGetResolvedInterfaceMethod));
    }
 
@@ -914,8 +1082,12 @@ TR::SymbolValidationManager::addMethodFromSingleInterfaceImplementerRecord(TR_Op
                                                                            int32_t cpIndex,
                                                                            TR_OpaqueMethodBlock *callerMethod)
    {
-   SVM_ASSERT_ALREADY_VALIDATED(this, thisClass);
-   SVM_ASSERT_ALREADY_VALIDATED(this, callerMethod);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(this, thisClass);
+      SVM_ASSERT_ALREADY_VALIDATED(this, callerMethod);
+      }
+
    return addMethodRecord(new (_region) MethodFromSingleInterfaceImplementer(method, thisClass, cpIndex, callerMethod));
    }
 
@@ -925,14 +1097,20 @@ TR::SymbolValidationManager::addMethodFromSingleAbstractImplementerRecord(TR_Opa
                                                                           int32_t vftSlot,
                                                                           TR_OpaqueMethodBlock *callerMethod)
    {
-   SVM_ASSERT_ALREADY_VALIDATED(this, thisClass);
-   SVM_ASSERT_ALREADY_VALIDATED(this, callerMethod);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      {
+      SVM_ASSERT_ALREADY_VALIDATED(this, thisClass);
+      SVM_ASSERT_ALREADY_VALIDATED(this, callerMethod);
+      }
+
    return addMethodRecord(new (_region) MethodFromSingleAbstractImplementer(method, thisClass, vftSlot, callerMethod));
    }
 
 bool
 TR::SymbolValidationManager::addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, bool skipFrames)
    {
+   SVM_ASSERT(!IS_RAM_CACHE_ON(_javaVM), "Calling addStackWalkerMaySkipFramesRecord in Image mode\n");
+
    if (!method || !methodClass)
       return false;
 
@@ -944,9 +1122,412 @@ TR::SymbolValidationManager::addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBl
 bool
 TR::SymbolValidationManager::addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized)
    {
-   SVM_ASSERT_ALREADY_VALIDATED(this, clazz);
+   if (!IS_RAM_CACHE_ON(_javaVM))
+      SVM_ASSERT_ALREADY_VALIDATED(this, clazz);
+
    return addVanillaRecord(clazz, new (_region) ClassInfoIsInitialized(clazz, isInitialized));
    }
+
+
+
+
+
+
+
+bool
+TR::SymbolValidationManager::writeRecordsToBuffer(void *buffer, uintptrj_t sizeOfBuffer)
+   {
+   TR_ASSERT_FATAL(sizeOfBuffer == _totalSizeOfRecords, "Buffer not the same size as total size of records: "
+                                                        "%llu, %llu\n",
+                   sizeOfBuffer, _totalSizeOfRecords);
+
+   uint8_t *cursor = (uint8_t *)buffer;
+   uintptrj_t bytesWritten = 0;
+
+   for (auto iter = _symbolValidationRecords.begin();
+        iter != _symbolValidationRecords.end() && bytesWritten < sizeOfBuffer;
+        iter++)
+      {
+      TR::SymbolValidationRecord *record = *iter;
+      uintptrj_t sizeOfRecord = getSizeOfRecord(record->_kind);
+
+      memcpy(cursor, record, sizeOfRecord);
+      cursor += sizeOfRecord;
+      bytesWritten += sizeOfRecord;
+      }
+
+   TR_ASSERT_FATAL(bytesWritten == _totalSizeOfRecords, "bytesWritten not the same size as total size of records: "
+                                                        "%llu, %llu\n",
+                   bytesWritten, _totalSizeOfRecords);
+
+   return true;
+   }
+
+bool
+TR::SymbolValidationManager::validateRecordsInBuffer(void *buffer, uintptrj_t sizeOfBuffer)
+   {
+   uint8_t *cursor = (uint8_t *)buffer;
+   uint8_t *endOfBuffer = cursor + sizeOfBuffer;
+
+   while (cursor < endOfBuffer)
+      {
+      TR::SymbolValidationRecord *svmRecord = (TR::SymbolValidationRecord *)cursor;
+      uintptrj_t sizeOfRecord = getSizeOfRecord(svmRecord->_kind);
+
+      switch (svmRecord->_kind)
+         {
+         case TR_ValidateClassByName:
+            {
+            TR::ClassByNameRecord *record = (TR::ClassByNameRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            J9ROMClass *romClass = (J9ROMClass *)record->_classChain;
+            J9UTF8 * classNameData = J9ROMCLASS_CLASSNAME(romClass);
+            char *className = reinterpret_cast<char *>(J9UTF8_DATA(classNameData));
+            uint32_t classNameLength = J9UTF8_LENGTH(classNameData);
+            TR_OpaqueClassBlock *clazz = _fej9->getClassFromSignature(className, classNameLength, beholderCP);
+
+            if (clazz != record->_class)
+               return false;
+            }
+            break;
+
+         case TR_ValidateClassFromCP:
+            {
+            TR::ClassFromCPRecord *record = (TR::ClassFromCPRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+            TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::getClassFromCP(_fej9, beholderCP, _comp, cpIndex);
+
+            if (clazz != record->_class)
+               return false;
+            }
+            break;
+
+         case TR_ValidateDefiningClassFromCP:
+            {
+            TR::DefiningClassFromCPRecord *record = (TR::DefiningClassFromCPRecord *)svmRecord;
+
+            TR::CompilationInfo *compInfo = TR::CompilationInfo::get(_fej9->_jitConfig);
+            TR::CompilationInfoPerThreadBase *compInfoPerThreadBase = compInfo->getCompInfoForCompOnAppThread();
+            TR_RelocationRuntime *reloRuntime;
+            if (compInfoPerThreadBase)
+               reloRuntime = compInfoPerThreadBase->reloRuntime();
+            else
+               reloRuntime = compInfo->getCompInfoForThread(_vmThread)->reloRuntime();
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+            bool isStatic = record->_isStatic;
+            TR_OpaqueClassBlock *clazz = reloRuntime->getClassFromCP(_vmThread, beholderCP, cpIndex, isStatic);
+
+            if (clazz != record->_class)
+               return false;
+            }
+            break;
+
+         case TR_ValidateStaticClassFromCP:
+            {
+            TR::StaticClassFromCPRecord *record = (TR::StaticClassFromCPRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+            TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::getClassOfStaticFromCP(_fej9, beholderCP, cpIndex);
+
+            if (clazz != record->_class)
+               return false;
+            }
+            break;
+
+         case TR_ValidateSystemClassByName:
+            {
+            TR::SystemClassByNameRecord *record = (TR::SystemClassByNameRecord *)svmRecord;
+
+            J9ROMClass *romClass = (J9ROMClass *)record->_classChain;
+            J9UTF8 * className = J9ROMCLASS_CLASSNAME(romClass);
+            TR_OpaqueClassBlock *systemClassByName = _fej9->getSystemClassFromClassName(reinterpret_cast<const char *>(J9UTF8_DATA(className)),
+                                                                                       J9UTF8_LENGTH(className));
+
+            if (systemClassByName != record->_class)
+               return false;
+            }
+            break;
+
+         case TR_ValidateClassFromITableIndexCP:
+            {
+            TR::ClassFromITableIndexCPRecord *record = (TR::ClassFromITableIndexCPRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+            uintptr_t pITableIndex;
+            TR_OpaqueClassBlock *clazz = TR_ResolvedJ9Method::getInterfaceITableIndexFromCP(_fej9, beholderCP, cpIndex, &pITableIndex);
+
+            if (clazz != record->_class)
+               return false;
+            }
+            break;
+
+         case TR_ValidateDeclaringClassFromFieldOrStatic:
+            {
+            TR::DeclaringClassFromFieldOrStaticRecord *record = (TR::DeclaringClassFromFieldOrStaticRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            uint32_t cpIndex = record->_cpIndex;
+            TR_OpaqueClassBlock *definingClass = getDeclaringClassFromFieldOrStatic(beholder, cpIndex);
+
+            if (definingClass != record->_class)
+               return false;
+            }
+            break;
+
+         case TR_ValidateStaticMethodFromCP:
+            {
+            TR::StaticMethodFromCPRecord *record = (TR::StaticMethodFromCPRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+            J9Method *ramMethod;
+
+               {
+               TR::VMAccessCriticalSection getResolvedStaticMethod(_fej9);
+               ramMethod = jitResolveStaticMethodRef(_vmThread, beholderCP, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
+               }
+
+            if (ramMethod != (J9Method *)record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateSpecialMethodFromCP:
+            {
+            TR::SpecialMethodFromCPRecord *record = (TR::SpecialMethodFromCPRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+            J9Method *ramMethod;
+
+               {
+               TR::VMAccessCriticalSection resolveSpecialMethodRef(_fej9);
+               ramMethod = jitResolveSpecialMethodRef(_vmThread, beholderCP, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME);
+               }
+
+            if (ramMethod != (J9Method *)record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateVirtualMethodFromCP:
+            {
+            TR::VirtualMethodFromCPRecord *record = (TR::VirtualMethodFromCPRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+
+            UDATA vTableOffset;
+            bool unresolvedInCP;
+            TR_OpaqueMethodBlock * ramMethod = TR_ResolvedJ9Method::getVirtualMethod(_fej9, beholderCP, cpIndex, &vTableOffset, &unresolvedInCP);
+
+            if (ramMethod != record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateVirtualMethodFromOffset:
+            {
+            TR::VirtualMethodFromOffsetRecord *record = (TR::VirtualMethodFromOffsetRecord *)svmRecord;
+
+            TR_OpaqueClassBlock *beholder = record->_beholder;
+            int32_t virtualCallOffset = record->_virtualCallOffset;
+            bool ignoreRtResolve = record->_ignoreRtResolve;
+
+            TR_OpaqueMethodBlock *ramMethod = _fej9->getResolvedVirtualMethod(beholder, virtualCallOffset, ignoreRtResolve);
+
+            if (ramMethod != record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateInterfaceMethodFromCP:
+            {
+            TR::InterfaceMethodFromCPRecord *record = (TR::InterfaceMethodFromCPRecord *)svmRecord;
+
+            TR_OpaqueClassBlock *lookup = record->_lookup;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+
+            TR_OpaqueMethodBlock *ramMethod = _fej9->getResolvedInterfaceMethod(beholderCP, lookup, cpIndex);
+
+            if (ramMethod != record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateImproperInterfaceMethodFromCP:
+            {
+            TR::ImproperInterfaceMethodFromCPRecord *record = (TR::ImproperInterfaceMethodFromCPRecord *)svmRecord;
+
+            J9Class *beholder = (J9Class *)record->_beholder;
+            J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
+            uint32_t cpIndex = record->_cpIndex;
+            J9Method *ramMethod;
+
+               {
+               TR::VMAccessCriticalSection resolveImproperMethodRef(_fej9);
+               ramMethod = jitGetImproperInterfaceMethodFromCP(_vmThread, beholderCP, cpIndex, NULL);
+               }
+
+            if (ramMethod != (J9Method *)record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateMethodFromClassAndSig:
+            {
+            TR::MethodFromClassAndSigRecord *record = (TR::MethodFromClassAndSigRecord *)svmRecord;
+
+            TR_OpaqueClassBlock *lookupClass = record->_lookupClass;
+            TR_OpaqueClassBlock *beholder = record->_beholder;
+
+            // Seems silly that we're using the ROM class from record->_method, then
+            // getting querying for the ram method using the name only to compare the
+            // result with record->method, but the point of this exercise is to see
+            // whether the cp entry is resolved.
+            J9ROMMethod *romMethod = _fej9->getROMMethodFromRAMMethod((J9Method *)record->_method);
+
+            J9UTF8 *methodNameData = J9ROMMETHOD_NAME(romMethod);
+            char *methodName = (char *)alloca(J9UTF8_LENGTH(methodNameData)+1);
+            strncpy(methodName, reinterpret_cast<const char *>(J9UTF8_DATA(methodNameData)), J9UTF8_LENGTH(methodNameData));
+            methodName[J9UTF8_LENGTH(methodNameData)] = '\0';
+
+            J9UTF8 *methodSigData = J9ROMMETHOD_SIGNATURE(romMethod);
+            char *methodSig = (char *)alloca(J9UTF8_LENGTH(methodSigData)+1);
+            strncpy(methodSig, reinterpret_cast<const char *>(J9UTF8_DATA(methodSigData)), J9UTF8_LENGTH(methodSigData));
+            methodSig[J9UTF8_LENGTH(methodSigData)] = '\0';
+
+            TR_OpaqueMethodBlock *method = _fej9->getMethodFromClass(lookupClass, methodName, methodSig, beholder);
+
+            if (method != record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateMethodFromSingleImplementer:
+            {
+            TR::MethodFromSingleImplementer *record = (TR::MethodFromSingleImplementer *)svmRecord;
+
+            TR_OpaqueClassBlock *thisClass = record->_thisClass;
+            TR_OpaqueMethodBlock *callerMethod = record->_callerMethod;
+            int32_t cpIndexOrVftSlot = record->_cpIndexOrVftSlot;
+            TR_YesNoMaybe useGetResolvedInterfaceMethod = record->_useGetResolvedInterfaceMethod;
+
+            TR_ResolvedMethod *callerResolvedMethod = _fej9->createResolvedMethod(_trMemory, callerMethod, NULL);
+            TR_ResolvedMethod *calleeResolvedMethod = _chTable->findSingleImplementer(thisClass, cpIndexOrVftSlot, callerResolvedMethod, _comp, false, useGetResolvedInterfaceMethod, false);
+
+            if (!calleeResolvedMethod)
+               return false;
+
+            TR_OpaqueMethodBlock *method = calleeResolvedMethod->getPersistentIdentifier();
+
+            if (method != record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateMethodFromSingleInterfaceImplementer:
+            {
+            TR::MethodFromSingleInterfaceImplementer *record = (TR::MethodFromSingleInterfaceImplementer *)svmRecord;
+
+            TR_OpaqueClassBlock *thisClass = record->_thisClass;
+            TR_OpaqueMethodBlock *callerMethod = record->_callerMethod;
+            int32_t cpIndex = record->_cpIndex;
+
+            TR_ResolvedMethod *callerResolvedMethod = _fej9->createResolvedMethod(_trMemory, callerMethod, NULL);
+            TR_ResolvedMethod *calleeResolvedMethod = _chTable->findSingleInterfaceImplementer(thisClass, cpIndex, callerResolvedMethod, _comp, false, false);
+
+            if (!calleeResolvedMethod)
+               return false;
+
+            TR_OpaqueMethodBlock *method = calleeResolvedMethod->getPersistentIdentifier();
+
+            if (method != record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateMethodFromSingleAbstractImplementer:
+            {
+            TR::MethodFromSingleAbstractImplementer *record = (TR::MethodFromSingleAbstractImplementer *)svmRecord;
+
+            TR_OpaqueClassBlock *thisClass = record->_thisClass;
+            TR_OpaqueMethodBlock *callerMethod = record->_callerMethod;
+            int32_t vftSlot = record->_vftSlot;
+
+            TR_ResolvedMethod *callerResolvedMethod = _fej9->createResolvedMethod(_trMemory, callerMethod, NULL);
+            TR_ResolvedMethod *calleeResolvedMethod = _chTable->findSingleAbstractImplementer(thisClass, vftSlot, callerResolvedMethod, _comp, false, false);
+
+            if (!calleeResolvedMethod)
+               return false;
+
+            TR_OpaqueMethodBlock *method = calleeResolvedMethod->getPersistentIdentifier();
+
+            if (method != record->_method)
+               return false;
+            }
+            break;
+
+         case TR_ValidateConcreteSubClassFromClass:
+            {
+            TR::ConcreteSubClassFromClassRecord *record = (TR::ConcreteSubClassFromClassRecord *)svmRecord;
+
+            TR_OpaqueClassBlock *superClass = record->_superClass;
+            TR_OpaqueClassBlock *childClass = _chTable->findSingleConcreteSubClass(superClass, _comp, false);
+
+            if (childClass != record->_childClass)
+               return false;
+            }
+            break;
+
+         case TR_ValidateClassInfoIsInitialized:
+            {
+            TR::ClassInfoIsInitialized *record = (TR::ClassInfoIsInitialized *)svmRecord;
+
+            TR_OpaqueClassBlock *clazz = record->_class;
+
+            bool initialized = false;
+
+            TR_PersistentClassInfo * classInfo =
+               _chTable->findClassInfoAfterLocking(clazz, _comp, true);
+
+            if (classInfo)
+               initialized = classInfo->isInitialized(false);
+
+            bool valid = (!record->_isInitialized || initialized);
+            return valid;
+            }
+            break;
+
+         default:
+            SVM_ASSERT(false, "Called validateRecordsInBuffer with invalid kind %d", svmRecord->_kind);
+            return false;
+         }
+
+      cursor += sizeOfRecord;
+      }
+
+   return true;
+   }
+
 
 
 
@@ -1124,10 +1705,9 @@ TR::SymbolValidationManager::validateClassFromITableIndexCPRecord(uint16_t class
    return validateSymbol(classID, TR_ResolvedJ9Method::getInterfaceITableIndexFromCP(_fej9, beholderCP, cpIndex, &pITableIndex));
    }
 
-bool
-TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex)
+TR_OpaqueClassBlock *
+TR::SymbolValidationManager::getDeclaringClassFromFieldOrStatic(J9Class *beholder, int32_t cpIndex)
    {
-   J9Class *beholder = getJ9ClassFromID(beholderID);
    J9ROMClass *beholderRomClass = beholder->romClass;
    J9ConstantPool *beholderCP = J9_CP_FROM_CLASS(beholder);
    J9ROMFieldRef *romCPBase = (J9ROMFieldRef *)((UDATA)beholderRomClass + sizeof(J9ROMClass));
@@ -1160,10 +1740,16 @@ TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint1
          NULL,
          J9_LOOK_NO_JAVA);
       }
-   else
-      {
-      return false;
-      }
+
+   return (TR_OpaqueClassBlock *)definingClass;
+   }
+
+bool
+TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint16_t definingClassID, uint16_t beholderID, int32_t cpIndex)
+   {
+   J9Class *beholder = getJ9ClassFromID(beholderID);
+
+   TR_OpaqueClassBlock *definingClass = getDeclaringClassFromFieldOrStatic(beholder, cpIndex);
 
    return validateSymbol(definingClassID, definingClass);
    }

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -298,6 +298,12 @@ void codert_freeJITConfig(J9JavaVM * javaVM)
 
    if (jitConfig && !freedJITConfig)
       {
+      printf("CompilerEnv=%p, PersistentAllocator=%p, PersistentMemory = %p\n",
+             TR::Compiler,
+             &TR::Compiler->persistentAllocator(),
+             ((TR_CacheForImage *)jitConfig->cacheForImage)->persistentMemory);
+      TR::Compiler->persistentAllocator().printSegments();
+
       if (IS_RAM_CACHE_ON(javaVM))
          {
          TR_PersistentMemory * persistentMemory = (TR_PersistentMemory *)jitConfig->scratchSegment;

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -37,6 +37,7 @@
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/ProcessorInfo.hpp"
+#include "env/PersistentCHTable.hpp"
 #include "infra/Monitor.hpp"
 #include "infra/MonitorTable.hpp"
 #include "runtime/ArtifactManager.hpp"
@@ -50,6 +51,8 @@
 char * feGetEnv(const char * s);
 
 TR::Monitor * assumptionTableMutex = NULL;
+
+static bool freedJITConfig = false;
 
 JIT_HELPER(icallVMprJavaSendVirtual0);
 JIT_HELPER(icallVMprJavaSendVirtual1);
@@ -293,17 +296,28 @@ void codert_freeJITConfig(J9JavaVM * javaVM)
    {
    J9JITConfig * jitConfig = javaVM->jitConfig;
 
-   if (jitConfig)
+   if (jitConfig && !freedJITConfig)
       {
+      if (IS_RAM_CACHE_ON(javaVM))
+         {
+         TR_PersistentMemory * persistentMemory = (TR_PersistentMemory *)jitConfig->scratchSegment;
+         TR_PersistentCHTable::destroy(persistentMemory->getPersistentInfo()->getPersistentCHTable());
+         persistentMemory->getPersistentInfo()->setPersistentCHTable(NULL);
+         }
+
       PORT_ACCESS_FROM_JAVAVM(javaVM);
 
       j9ThunkTableFree(javaVM);
 
       if (jitConfig->translationArtifacts)
          avl_jit_artifact_free_all(javaVM, jitConfig->translationArtifacts);
+      jitConfig->translationArtifacts = NULL;
 
-      if (jitConfig->codeCacheList)
-         javaVM->internalVMFunctions->freeMemorySegmentList(javaVM, jitConfig->codeCacheList);
+      if (!IS_RAM_CACHE_ON(javaVM))
+         {
+         if (jitConfig->codeCacheList)
+            javaVM->internalVMFunctions->freeMemorySegmentList(javaVM, jitConfig->codeCacheList);
+         }
 
 #if defined(TR_TARGET_S390)
       if (jitConfig->pseudoTOC)
@@ -326,12 +340,14 @@ void codert_freeJITConfig(J9JavaVM * javaVM)
          }
 #endif
 
-      TR::CodeCacheManager *manager = TR::CodeCacheManager::instance();
-      if (manager)
-         manager->destroy();
+      if (!IS_RAM_CACHE_ON(javaVM))
+         {
+         TR::CodeCacheManager *manager = TR::CodeCacheManager::instance();
+         if (manager)
+            manager->destroy();
 
-      TR_DataCacheManager::destroyManager();
-
+         TR_DataCacheManager::destroyManager();
+         }
 
       // Destroy faint blocks
       OMR::FaintCacheBlock *currentFaintBlock = (OMR::FaintCacheBlock *)jitConfig->methodsToDelete;
@@ -364,15 +380,20 @@ void codert_freeJITConfig(J9JavaVM * javaVM)
 
       jitConfig->valid = (UDATA)0;
 
-      j9mem_free_memory(jitConfig);
+      if (!IS_RAM_CACHE_ON(javaVM))
+         {
+         j9mem_free_memory(jitConfig);
 
-      /* Finally break the connection between the VM and the JIT */
-      javaVM->jitConfig = NULL;
+         /* Finally break the connection between the VM and the JIT */
+         javaVM->jitConfig = NULL;
 
-      // TEMP FIX for 97269, re-enable when the similar problem for 92051
-      // above is fixed.
+         // TEMP FIX for 97269, re-enable when the similar problem for 92051
+         // above is fixed.
 
-      TR::MonitorTable::get()->free();
+         TR::MonitorTable::get()->free();
+         }
+
+      freedJITConfig = true;
       }
    }
 

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -29,6 +29,8 @@
 #include "jitprotos.h"
 #include "j9.h"
 #include "j9cfg.h"
+#include "jvmimage.h"
+#include "jvmimageport.h"
 #include "j9consts.h"
 #include "j9protos.h"
 #include "stackwalk.h"
@@ -168,6 +170,7 @@ J9JITConfig * codert_onload(J9JavaVM * javaVM)
    J9JITConfig * jitConfig = NULL;
    PORT_ACCESS_FROM_JAVAVM(javaVM);
    OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+   JVMIMAGEPORT_ACCESS_FROM_JAVAVM(javaVM);
 
    #if defined(TR_HOST_X86) && !defined(TR_HOST_64BIT)
       vmThreadTLSKey = (U_32) javaVM->omrVM->_vmThreadKey;
@@ -190,22 +193,35 @@ J9JITConfig * codert_onload(J9JavaVM * javaVM)
    if (!TR::MonitorTable::init(privatePortLibrary, javaVM))
       goto _abort;
 
-   TR_ASSERT(!javaVM->jitConfig, "jitConfig already initialized.");
+   if (!IS_RAM_CACHE_ON(javaVM) || IS_COLD_RUN(javaVM))
+      {
+      TR_ASSERT(!javaVM->jitConfig, "jitConfig already initialized.");
 
 #if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
-   javaVM->jitConfig = (J9JITConfig *) j9mem_allocate_memory(sizeof(J9AOTConfig), J9MEM_CATEGORY_JIT);
+      if (IS_RAM_CACHE_ON(javaVM))
+         javaVM->jitConfig = (J9JITConfig *) imem_allocate_memory(sizeof(J9AOTConfig), J9MEM_CATEGORY_JIT);
+      else
+         javaVM->jitConfig = (J9JITConfig *) j9mem_allocate_memory(sizeof(J9AOTConfig), J9MEM_CATEGORY_JIT);
 #else
-   javaVM->jitConfig = (J9JITConfig *) j9mem_allocate_memory(sizeof(J9JITConfig), J9MEM_CATEGORY_JIT);
+      if (IS_RAM_CACHE_ON(javaVM))
+         javaVM->jitConfig = (J9JITConfig *) imem_allocate_memory(sizeof(J9JITConfig), J9MEM_CATEGORY_JIT);
+      else
+         javaVM->jitConfig = (J9JITConfig *) j9mem_allocate_memory(sizeof(J9JITConfig), J9MEM_CATEGORY_JIT);
 #endif
+
+      if (javaVM->jitConfig)
+         {
+#if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
+         memset(javaVM->jitConfig, 0, sizeof(J9AOTConfig));
+#else
+         memset(javaVM->jitConfig, 0, sizeof(J9JITConfig));
+#endif
+         }
+      }
 
    if (!javaVM->jitConfig)
       goto _abort;
 
-#if defined(J9VM_INTERP_AOT_COMPILE_SUPPORT)
-   memset(javaVM->jitConfig, 0, sizeof(J9AOTConfig));
-#else
-   memset(javaVM->jitConfig, 0, sizeof(J9JITConfig));
-#endif
    jitConfig = javaVM->jitConfig;
    jitConfig->sampleInterruptHandlerKey = -1;
 
@@ -310,43 +326,6 @@ void codert_freeJITConfig(J9JavaVM * javaVM)
          }
 #endif
 
-/*  Commented out because of rare failure during shutdown: 90700: JIT_Sanity.TestSCCMLTests1.Mode110 Crash during freeJITconfig()
-    Deallocating malloced memory is not going to very useful even for zOS
-
-      // Free the caches for fast stack walk mechanism
-      // before freeing the data caches or code caches
-      J9MemorySegment *dataCacheSeg = jitConfig->dataCacheList->nextSegment;
-      while (dataCacheSeg) // Iterate over all the data cache segments
-         {
-         // Iterate over all records in the data cache segment
-         UDATA current = (UDATA)dataCacheSeg->heapBase;
-         UDATA end = (UDATA)dataCacheSeg->heapAlloc;
-         while (current < end)
-            {
-            J9JITDataCacheHeader * hdr = (J9JITDataCacheHeader *)current;
-            if (hdr->type == J9DataTypeExceptionInfo)
-               {
-               J9JITExceptionTable * metaData = (J9JITExceptionTable *)(current + sizeof(J9JITDataCacheHeader));
-               // Don't look at unloaded metaData
-               if (metaData->constantPool != NULL)
-                  {
-                  if (metaData->bodyInfo != NULL)
-                     {
-                     void *mapTablePtr = ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->getMapTable();
-                     if (mapTablePtr != (void*)-1 && mapTablePtr != NULL)
-                        {
-                        j9mem_free_memory(mapTablePtr);
-                        ((TR_PersistentJittedBodyInfo *)metaData->bodyInfo)->setMapTable(NULL);
-                        }
-                     }
-                  }
-               }
-            current += hdr->size;
-            }
-         dataCacheSeg = dataCacheSeg->nextSegment;
-         } // end while (dataCacheSeg)
-
-*/
       TR::CodeCacheManager *manager = TR::CodeCacheManager::instance();
       if (manager)
          manager->destroy();

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -264,6 +264,8 @@ J9JITConfig * codert_onload(J9JavaVM * javaVM)
    jitConfig->osrScratchBufferMaximumSize = (UDATA) 1024;
    jitConfig->osrStackFrameMaximumSize = (UDATA) 8192;
 
+   jitConfig->valid = (UDATA)1;
+
    return jitConfig;
 
    _abort:
@@ -380,6 +382,9 @@ void codert_freeJITConfig(J9JavaVM * javaVM)
          j9mem_free_memory(jitConfig->privateConfig);
          jitConfig->privateConfig = NULL;
          }
+
+      jitConfig->valid = (UDATA)0;
+
       j9mem_free_memory(jitConfig);
 
       /* Finally break the connection between the VM and the JIT */

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -58,6 +58,10 @@
 #include "runtime/J9Profiler.hpp"
 #include "runtime/J9ValueProfiler.hpp"
 
+#include "jvmimage.h"
+#include "jvmimageport.h"
+#include "control/CompilationRuntime.hpp"
+
 #ifdef TR_TARGET_64BIT
 #include "x/amd64/codegen/AMD64GuardedDevirtualSnippet.hpp"
 #else
@@ -1737,6 +1741,11 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
    void *virtualThunk = NULL;
    if (getProperties().getNeedsThunksForIndirectCalls())
       {
+      if (IS_RAM_CACHE_ON(TR::CompilationInfo::get()->getJITConfig()->javaVM))
+         {
+         comp()->failCompilation<TR::CompilationException>("Compilation uses thunks for indirect calls!");
+         }
+
       TR::MethodSymbol *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
       TR::Method       *method       = methodSymbol->getMethod();
       if (methodSymbol->isComputed())

--- a/runtime/makelib/targets.mk.linux.inc.ftl
+++ b/runtime/makelib/targets.mk.linux.inc.ftl
@@ -47,7 +47,7 @@ $(UMA_DLLTARGET) : $(UMA_OBJECTS) $(UMA_TARGET_LIBRARIES)
 		$(UMA_DLL_LINK_POSTFLAGS)
 ifdef j9vm_uma_gnuDebugSymbols
 	$(OBJCOPY) --only-keep-debug $(UMA_DLLTARGET) $(UMA_DLLTARGET).dbg
-	$(OBJCOPY) --strip-debug $(UMA_DLLTARGET)
+	$(OBJCOPY) $(UMA_DLLTARGET)
 	$(OBJCOPY) --add-gnu-debuglink=$(UMA_DLLTARGET).dbg $(UMA_DLLTARGET)
 endif
 </#assign>
@@ -105,13 +105,13 @@ ifndef UMA_DO_NOT_OPTIMIZE_CCODE
     UMA_OPTIMIZATION_CFLAGS += ${uma.spec.properties.uma_optimization_cflags.value}
   <#else>
     <#if uma.spec.processor.amd64 || uma.spec.processor.riscv64>
-      UMA_OPTIMIZATION_CFLAGS += -O3 -fno-strict-aliasing
+      UMA_OPTIMIZATION_CFLAGS += -O3 -O0 -fno-strict-aliasing
     <#elseif uma.spec.processor.x86>
-      UMA_OPTIMIZATION_CFLAGS += -O3 -fno-strict-aliasing -march=pentium4 -mtune=prescott -mpreferred-stack-boundary=4
+      UMA_OPTIMIZATION_CFLAGS += -g3 -O0 -fno-strict-aliasing -march=pentium4 -mtune=prescott -mpreferred-stack-boundary=4
     <#elseif uma.spec.processor.arm>
-      UMA_OPTIMIZATION_CFLAGS += -g -O3 -fno-strict-aliasing $(ARM_ARCH_FLAGS) -Wno-unused-but-set-variable
+      UMA_OPTIMIZATION_CFLAGS += -g3 -O0 -fno-strict-aliasing $(ARM_ARCH_FLAGS) -Wno-unused-but-set-variable
     <#elseif uma.spec.processor.ppc>
-      UMA_OPTIMIZATION_CFLAGS += -O3
+      UMA_OPTIMIZATION_CFLAGS += -O0
       <#if uma.spec.flags.env_gcc.enabled>
         UMA_OPTIMIZATION_CFLAGS += -fno-strict-aliasing
       </#if>
@@ -122,7 +122,7 @@ ifndef UMA_DO_NOT_OPTIMIZE_CCODE
         endif
       </#if>
     <#elseif uma.spec.processor.s390>
-      UMA_OPTIMIZATION_CFLAGS += -O3 -mtune=z10 -march=z9-109 -mzarch
+      UMA_OPTIMIZATION_CFLAGS += -O0 -mtune=z10 -march=z9-109 -mzarch
     <#else>
       UMA_OPTIMIZATION_CFLAGS += -O
     </#if>
@@ -131,13 +131,13 @@ ifndef UMA_DO_NOT_OPTIMIZE_CCODE
     UMA_OPTIMIZATION_CXXFLAGS += ${uma.spec.properties.uma_optimization_cxxflags.value}
   <#else>
     <#if uma.spec.processor.amd64 || uma.spec.processor.riscv64>
-      UMA_OPTIMIZATION_CXXFLAGS += -O3 -fno-strict-aliasing
+      UMA_OPTIMIZATION_CXXFLAGS += -O3 -O0 -fno-strict-aliasing
     <#elseif uma.spec.processor.x86>
-      UMA_OPTIMIZATION_CXXFLAGS += -O3 -fno-strict-aliasing -march=pentium4 -mtune=prescott -mpreferred-stack-boundary=4
+      UMA_OPTIMIZATION_CXXFLAGS += -g3 -O0 -fno-strict-aliasing -march=pentium4 -mtune=prescott -mpreferred-stack-boundary=4
     <#elseif uma.spec.processor.arm>
-      UMA_OPTIMIZATION_CXXFLAGS += -g -O3 -fno-strict-aliasing $(ARM_ARCH_FLAGS) -Wno-unused-but-set-variable
+      UMA_OPTIMIZATION_CXXFLAGS += -g3 -O0 -fno-strict-aliasing $(ARM_ARCH_FLAGS) -Wno-unused-but-set-variable
     <#elseif uma.spec.processor.ppc>
-      UMA_OPTIMIZATION_CXXFLAGS += -O3
+      UMA_OPTIMIZATION_CXXFLAGS += -O0
       <#if uma.spec.flags.env_gcc.enabled>
         UMA_OPTIMIZATION_CXXFLAGS += -fno-strict-aliasing
       </#if>
@@ -145,7 +145,7 @@ ifndef UMA_DO_NOT_OPTIMIZE_CCODE
         UMA_OPTIMIZATION_CXXFLAGS += -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
       </#if>
     <#elseif uma.spec.processor.s390>
-      UMA_OPTIMIZATION_CXXFLAGS += -O3 -mtune=z10 -march=z9-109 -mzarch
+      UMA_OPTIMIZATION_CXXFLAGS += -O0 -mtune=z10 -march=z9-109 -mzarch
     <#else>
       UMA_OPTIMIZATION_CXXFLAGS += -O
     </#if>
@@ -159,7 +159,7 @@ CFLAGS += $(UMA_OPTIMIZATION_CFLAGS)
 CXXFLAGS += $(UMA_OPTIMIZATION_CXXFLAGS)
 <#if uma.spec.processor.ppc>
   ifdef USE_PPC_GCC
-    PPC_GCC_CXXFLAGS += -O3 -fno-strict-aliasing
+    PPC_GCC_CXXFLAGS += -O0 -fno-strict-aliasing
   endif
 </#if>
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3764,6 +3764,8 @@ typedef struct J9JITConfig {
 	void ( *jitIllegalFinalFieldModification)(struct J9VMThread *currentThread, struct J9Class *fieldClass);
 	U_8* (*codeCacheWarmAlloc)(void *codeCache);
 	U_8* (*codeCacheColdAlloc)(void *codeCache);
+   void *cacheForImage;
+   UDATA valid;
 } J9JITConfig;
 
 #define J9JIT_GROW_CACHES  0x100000

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -532,6 +532,8 @@ typedef struct J9JITExceptionTable {
 	UDATA codeCacheAlloc;
 	void* gpuCode;
 	void* riData;
+	void* shadowCodeStart;
+	void* reloBuffer;
 } J9JITExceptionTable;
 
 #define JIT_METADATA_FLAGS_USED_FOR_SIZE 1

--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -23,12 +23,13 @@
 #include "JVMImage.hpp"
 #include "segment.h"
 #include <errno.h>
+#include <string.h>
 
 #include <sys/mman.h> /* TODO: Change to OMRPortLibrary MMAP functionality. Currently does not allow MAP_FIXED as it is not supported in all architectures */
 
 /* TODO: reallocation will fail so initial heap size is large (Should be PAGE_SIZE aligned) */
 /* TODO: initial image size restriction will be removed once MMAP MAP_FIXED removed. see @ref JVMImage::readImageFromFile */
-const UDATA JVMImage::INITIAL_IMAGE_SIZE = 100 * 1024 * 1024;
+const UDATA JVMImage::INITIAL_IMAGE_SIZE = (1024 + 256) * 1024 * 1024;
 const UDATA JVMImage::CLASS_LOADER_REMOVE_COUNT = 8;
 
 JVMImage::JVMImage(J9PortLibrary *portLibrary, const char* ramCache) :
@@ -64,10 +65,12 @@ JVMImage::getJ9JavaVM()
 
 JVMImage::~JVMImage()
 {
-	PORT_ACCESS_FROM_JAVAVM(_vm);
+	//PORT_ACCESS_FROM_JAVAVM(_vm);
 	destroyMonitor();
 	if (IS_COLD_RUN(_vm)) {
-		j9mem_free_memory((void*)_jvmImageHeader->imageAddress);
+		//j9mem_free_memory((void*)_jvmImageHeader->imageAddress);
+		//UDATA pageSize = j9vmem_supported_page_sizes()[0];
+		munmap((void*)_jvmImageHeader, _jvmImageHeader->imageSize);
 	} else {
 		munmap((void*)_jvmImageHeader, _jvmImageHeader->imageAlignedAddress);
 	}
@@ -188,15 +191,23 @@ JVMImage::allocateImageMemory(UDATA size)
 {
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 	UDATA pageSize = j9vmem_supported_page_sizes()[0];
-	void *imageAddress = j9mem_allocate_memory(size + pageSize, J9MEM_CATEGORY_CLASSES);
-	if (NULL == imageAddress) {
+	//void *imageAddress = j9mem_allocate_memory(size + pageSize, J9MEM_CATEGORY_CLASSES);
+        void *imageAddress = mmap(
+		0,
+		size + pageSize,
+		PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+	printf ("\n\n\nD_QWERTY: imageAddress = %p, errno=%s\n\n\n", imageAddress, strerror(errno));
+
+	if (NULL == imageAddress || (void *)-1 == imageAddress) {
 		return NULL;
 	}
 
-	_jvmImageHeader = (JVMImageHeader *) ROUND_UP_TO_POWEROF2((UDATA)imageAddress, pageSize);
+	//_jvmImageHeader = (JVMImageHeader *) ROUND_UP_TO_POWEROF2((UDATA)imageAddress, pageSize);
+	_jvmImageHeader = (JVMImageHeader *)imageAddress;
 	_jvmImageHeader->imageAddress = (uintptr_t)imageAddress;
 	_jvmImageHeader->imageAlignedAddress = (uintptr_t)_jvmImageHeader;
-	_jvmImageHeader->imageSize = size;
+	_jvmImageHeader->imageSize = size + pageSize;
 
 	return _jvmImageHeader;
 }
@@ -542,7 +553,9 @@ JVMImage::fixupVMStructures(void)
 	UDATA omrRuntimeOffset = ROUND_UP_TO_POWEROF2(sizeof(J9JavaVM), 8);
 	UDATA omrVMOffset = ROUND_UP_TO_POWEROF2(omrRuntimeOffset + sizeof(OMR_Runtime), 8);
 	UDATA vmAllocationSize = omrVMOffset + sizeof(OMR_VM);
+	J9JITConfig *jitConfig = _vm->jitConfig;
 	memset(_vm, 0, vmAllocationSize);
+	_vm->jitConfig = jitConfig;
 }
 
 void

--- a/runtime/vm/vmhook.c
+++ b/runtime/vm/vmhook.c
@@ -154,7 +154,7 @@ J9HookInterface**
 getJITHookInterface(J9JavaVM* vm)
 {
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
-	if (vm->jitConfig) {
+	if (vm->jitConfig && vm->jitConfig->valid) {
 		return J9_HOOK_INTERFACE(vm->jitConfig->hookInterface);
 	}
 #endif


### PR DESCRIPTION
## Overview

Depends on the commits in https://github.com/dsouzai/omr/tree/classPersistence

I've guarded the JIT code appropriately so that the OpenJDK-OpenJ9 build process works fine (there is no longer a need to build the VM first and then the JIT).

These changes include the commit that results in the build having all symbols; therefore to build:

```
make all && cp build/linux-x86_64-normal-server-release/vm/lib* build/linux-x86_64-normal-server-release/images/j2sdk-image/jre/lib/amd64/default/
```

The test I'm running is a very simple Hello World program:
```
$ cat HelloWorld.java 
class HelloWorld {
	public static void main (String args[]) {
		System.out.println("Hello World");
	}
}
```

## Issues

**Persistent memory**
For some reason, if I use Persistent Memory segments from `segment.c` as the backing memory for Persistent Memory, I get crashes during bootstrap in the second run. My guess is that the `std::dequeue` in `J9::PersistentAllocator` gets messed up somehow - maybe it gets destructed or something though I'm not sure _why_ it would since the destructor of `J9::PersistentAllocator` isn't called. 

For now, I just hijacked the `allocate` and `deallocate` routines to call (via `TR::RawAllocator`) `imem_allocate_memory`, which seems to have fixed the bootstrap issues.

~**java/lang/RuntimeException**~ FIXED.
I ran the Hello World program as follows:
```
gdb --args ../j2sdk-image/bin/java -Xshare:off -Xrs '-Xjit:optLevel=noOpt,verbose={compilePerformance},vlog=vlog,limit={com/ibm/jit/JITHelpers.getCharFromArrayByIndex(Ljava/lang/Object;I)C}' -Xramcache=test   HelloWorld 
```
This results in **only** `com/ibm/jit/JITHelpers.getCharFromArrayByIndex(Ljava/lang/Object;I)C` getting compiled at opt level `noOpt` (which doesn't have any inlining). The first run ends normally. The second run fails with:
```
Exception in thread "main" java/lang/ExceptionInInitializerError
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
java/lang/RuntimeException: Unknown array type for bit manipulation
	at com/ibm/jit/JITHelpers.getCharFromArrayByIndex (JITHelpers.java:534)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
	at (Unknown Method)
```
The `(Unknown Method)` is is a result of an issue searching the AVL tree that finds the name of a class based on the PC for interpreter frames. 

Will need to trace the method to see what the issue is; my initial guess is that it's related to a `ResolveCHK` which is a helper that gets called to resolve something, but then patches the code; in the second run, the code remains patched but this has the consequence of not triggering the resolution.