### PR TITLE
Fix compilation error and perf issue

### DIFF
--- a/runtime/vm/JVMImage.cpp
+++ b/runtime/vm/JVMImage.cpp
@@ -750,7 +750,7 @@ JVMImage::readImageFromFile(void)
 	_jvmImageHeader = (JVMImageHeader *)mmap(
 		(void *)imageHeaderBuffer.imageAlignedAddress,
 		imageHeaderBuffer.imageSize,
-		PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_FIXED | MAP_POPULATE, fileDescriptor, 0);
+		PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_FIXED, fileDescriptor, 0);
 	if (-1 == (IDATA)_jvmImageHeader) {
 		return false;
 	}

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -968,7 +968,7 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 
 		imagePortLib = initializeJVMImage(portLibrary, isColdRun, createParams->ramCache);
 
-		if (FALSE == imagePortLib) {
+		if (NULL == imagePortLib) {
 			return JNI_ENOMEM;
 		}
 		if (isColdRun) {


### PR DESCRIPTION
Adding MAP_POPULATE to preload page tables caused a regression.

Latest perf tests with Hello world shows `-Xramcache` is 82% faster