### PR TITLE
Add teardown stage to System.exit paths

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -280,12 +280,13 @@ gcCleanupHeapStructures(J9JavaVM * vm)
 	if (NULL != gam) {
 		gam->flushAllocationContextsForShutdown(&env);
 	}
-
-	if (vm->memorySegments) {
-		vm->internalVMFunctions->freeMemorySegmentList(vm, vm->memorySegments);
-	}
-	if (vm->classMemorySegments) {
-		vm->internalVMFunctions->freeMemorySegmentList(vm, vm->classMemorySegments);
+	if (!IS_WARM_RUN(vm)) {
+		if (vm->memorySegments) {
+			vm->internalVMFunctions->freeMemorySegmentList(vm, vm->memorySegments);
+		}
+		if (vm->classMemorySegments) {
+			vm->internalVMFunctions->freeMemorySegmentList(vm, vm->classMemorySegments);
+		}
 	}
 
 #if defined(J9VM_GC_FINALIZATION)

--- a/runtime/jcl/common/clsldr.cpp
+++ b/runtime/jcl/common/clsldr.cpp
@@ -70,6 +70,8 @@ Java_java_lang_ClassLoader_defineClassImpl(JNIEnv *env, jobject receiver, jstrin
 		options |= J9_FINDCLASS_FLAG_UNSAFE;
 	}
 
+	options |= J9_FINDCLASS_FLAG_CREATED_BY_DEFINE_CLASS;
+
 	jclass result = defineClassCommon(env, receiver, className, classRep, offset, length, protectionDomain, options, NULL);
 
 	if (J9_ARE_ANY_BITS_SET(options, J9_FINDCLASS_FLAG_NAME_IS_INVALID) && (NULL == result) && (NULL == currentThread->currentException)) {

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -407,6 +407,7 @@ extern "C" {
  * (see J9ClassIsExemptFromValidation), a NoClassDefFoundError will be thrown.
  */
 #define J9_FINDCLASS_FLAG_NAME_IS_INVALID 0x10000
+#define J9_FINDCLASS_FLAG_CREATED_BY_DEFINE_CLASS 0x20000
 
 #define J9_FINDKNOWNCLASS_FLAG_INITIALIZE 0x1
 #define J9_FINDKNOWNCLASS_FLAG_EXISTING_ONLY 0x2

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -81,6 +81,9 @@
 #define J9ClassContainsUnflattenedFlattenables 0x4000
 #define J9ClassCanSupportFastSubstitutability 0x8000
 #define J9ClassIsLoadedFromImage 0x10000
+#define J9ClassCreatedFromDefineClass 0x20000
+#define J9ClassLoadedFromDefineClass 0x40000
+/* TODO J9ClassIsLoadedFromImage and J9ClassLoadedFromDefineClass can be merged into one */
 
 /* @ddr_namespace: map_to_type=J9FieldFlags */
 

--- a/runtime/oti/jvmimage.h
+++ b/runtime/oti/jvmimage.h
@@ -28,6 +28,9 @@
 #define IS_COLD_RUN(javaVM) J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_COLD_RUN)
 #define IS_RAM_CACHE_ON(javaVM) J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_RAMSTATE_COLD_RUN | J9_EXTENDED_RUNTIME2_RAMSTATE_WARM_RUN)
 
+#define CAN_LOAD_DIRECT_FROM_CLASSTABLE(clazz) (J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassCreatedFromDefineClass | J9ClassLoadedFromDefineClass) \
+		|| J9_ARE_NO_BITS_SET((clazz)->classFlags, J9ClassCreatedFromDefineClass))
+
 /* Page size allocation macros needed for MMAP MAP_FIXED to work. see @ref JVMImage::readImageFromFile */
 /* TODO: remove once MMAP is not used anymore (random memory loading) */
 #define PAGE_SIZE 4096 /* PAGE Size only defined for certain architectures (4KB default) */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -896,6 +896,9 @@ growJavaStack(J9VMThread * vmThread, UDATA newStackSize);
 void
 initializeMethodRunAddress(J9VMThread *vmThread, J9Method *method);
 
+void
+initializeMethodRunAddressImpl(J9VMThread *vmThread, J9Method *method, BOOLEAN runHook);
+
 
 /**
 * @brief

--- a/runtime/vm/JVMImage.hpp
+++ b/runtime/vm/JVMImage.hpp
@@ -85,6 +85,8 @@ private:
 	bool restorePrimitiveAndArrayClasses(void);
 	bool restoreJ9JavaVMStructures(void);
 	void setPrimitiveAndArrayClasses(J9JavaVM *vm);
+	bool isImmortalClassLoader(J9ClassLoader *classLoader);
+	J9MemorySegmentList* copyUnPersistedMemorySegmentsToNewList(J9MemorySegmentList *oldMemorySegmentList);
 
 protected:
 	void *operator new(size_t size, void *memoryPointer) { return memoryPointer; }

--- a/runtime/vm/initsendtarget.cpp
+++ b/runtime/vm/initsendtarget.cpp
@@ -154,6 +154,12 @@ initializeMethodRunAddressVarHandle(J9Method *method)
 void
 initializeMethodRunAddress(J9VMThread *vmThread, J9Method *method)
 {
+	initializeMethodRunAddressImpl(vmThread, method, TRUE);
+}
+
+void
+initializeMethodRunAddressImpl(J9VMThread *vmThread, J9Method *method, BOOLEAN runHook)
+{
 	J9JavaVM* vm = vmThread->javaVM;
 
 	method->extra = (void *) J9_STARTPC_NOT_TRANSLATED;
@@ -162,7 +168,7 @@ initializeMethodRunAddress(J9VMThread *vmThread, J9Method *method)
 		return;
 	}
 
-	if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_INITIALIZE_SEND_TARGET)) {
+	if (runHook && J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_INITIALIZE_SEND_TARGET)) {
 		method->methodRunAddress = NULL;
 		ALWAYS_TRIGGER_J9HOOK_VM_INITIALIZE_SEND_TARGET(vm->hookInterface, vmThread, method);
 		if (NULL != method->methodRunAddress) {

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -795,3 +795,7 @@ TraceExit=Trc_VM_DeregisterInTable_Exit NoEnv Overhead=1 Level=1 Template="Table
 TraceEvent=Trc_VM_ImageClassLoaderRegister NoEnv Overhead=1 Level=1 Template="Classloader located at %p. Classloader ID is %d."
 TraceEvent=Trc_VM_ImageClassRegister Overhead=1 Level=1 Template="Class located at %p. Class Name is %s."
 TraceEvent=Trc_VM_ImageCPEntryRegister NoEnv Overhead=1 Level=1 Template="ClassPath located at %p. ClassPath Name is %s."
+
+TraceEvent=Trc_VM_warmClassLoadHookFailed Overhead=1 Level=1 Template="Warm class load hook failed class=%p, %s"
+
+TraceEvent=Trc_VM_loadWarmClass Overhead=1 Level=1 Template="LoadClass clazz=%p, %s"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -561,6 +561,10 @@ void OMRNORETURN exitJavaVM(J9VMThread * vmThread, IDATA rc)
 		omrthread_monitor_enter(vm->classLoaderBlocksMutex);
 #endif
 
+		if (IS_COLD_RUN(vm)) {
+			teardownJVMImage(vm);
+		}
+
 #if defined(COUNT_BYTECODE_PAIRS)
 		printBytecodePairs(vm);
 #endif /* COUNT_BYTECODE_PAIRS */

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -466,9 +466,10 @@ J9MemorySegmentList *allocateMemorySegmentListWithSize(J9JavaVM * javaVM, U_32 n
 			imem_free_memory(segmentList);
 			return NULL;
 		}
-	} else if (NULL == (segmentList = j9mem_allocate_memory(sizeof(J9MemorySegmentList), memoryCategory))) {
-		return NULL;
-	} else {
+	} else { 
+		if (NULL == (segmentList = j9mem_allocate_memory(sizeof(J9MemorySegmentList), memoryCategory))) {
+			return NULL;
+		}
 		segmentList->segmentPool = pool_new(sizeOfElements, numberOfMemorySegments, 0, 0, J9_GET_CALLSITE(), memoryCategory, POOL_FOR_PORT(PORTLIB));
 		if (!(segmentList->segmentPool)) {
 			j9mem_free_memory(segmentList);


### PR DESCRIPTION
Modify classload sequnce to differentiate between class loaded by define
class and classes loaded by the bootstrap loader

Signed-off-by: tajila <atobia@ca.ibm.com>